### PR TITLE
Add GH Action to enforce no-reply commit author settings for Bentley/Seequent contributors

### DIFF
--- a/.github/workflows/audit-commits.yml
+++ b/.github/workflows/audit-commits.yml
@@ -1,0 +1,29 @@
+name: Audit commits
+
+on:
+  pull_request:
+
+permissions:
+  pull-requests: read
+
+env:
+  PR_NUMBER: ${{ github.event.number }}
+  GH_TOKEN: ${{ github.token }}
+
+jobs:
+  audit-commits:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check for organisation email addresses in commits
+        shell: bash
+        run: |
+          EMAILS=$(gh pr view ${{ env.PR_NUMBER }} --json commits | jq .commits[].authors[].email)
+          if [[ $(echo $EMAILS | grep -i "@seequent.com") || $(echo $EMAILS | grep -i "@bentley.com") ]]; then
+            echo "Please enable 'no-reply' commit settings in your GitHub account"
+            echo "See https://docs.github.com/articles/setting-your-email-in-git"
+            exit 1
+          fi

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout Repo
+      - name: Checkout repository
         uses: actions/checkout@v4
     
       - name: Set up Python 3.11

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: checkout repo
+      - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Set up Python 3.11

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,3 +31,7 @@ repos:
       language: python
       additional_dependencies: ["jsonschema==4.17.3", "semver>=2.13,<3"]
       pass_filenames: false
+  -   id: audit-commits
+      name: Audit commit
+      language: script
+      entry: ./tools/audit-commits.sh

--- a/tools/audit-commits.sh
+++ b/tools/audit-commits.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Checks a commit to ensure Seequent or Bentley emails were not used
+
+EMAIL=$(git config user.email)
+
+if [[ $(echo $EMAIL | grep -i "@seequent.com") || $(echo $EMAIL | grep -i "@bentley.com") ]]; then
+  echo "Please enable 'no-reply' commit settings in your GitHub account"
+  echo "See https://docs.github.com/articles/setting-your-email-in-git"
+  exit 1
+fi


### PR DESCRIPTION
Adds a pre-commit hook and a CI workflow to prevent Bentley/Seequent email addresses from being used in commits.