### PR TITLE
Add evo-schemas-maintainers group to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
+* @seequentevo/evo-schemas-maintainers
 * @johnmgood


### PR DESCRIPTION
## Description

This group has been created to provide maintainership permissions to a group of people. Adding them to the codeowners file so they will be automatically requested for review.


## Checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have read the contributing guide and the code of conduct
