### PR TITLE
Fix building Python wheel into dist folder

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,14 +25,14 @@ jobs:
         run: pip install --upgrade pip .[test,release]
 
       - name: Build wheel
-        run: python -m pip wheel --no-deps .
+        run: python -m pip wheel --no-deps . -w dist
 
       - name: Publish wheel to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
 
       - name: Bundle JSON schemas
-        run: zip -r evo-schemas-${{ github.event.release.tag_name }}-schemas.zip schema
+        run: zip -r dist/evo-schemas-${{ github.event.release.tag_name }}-schemas.zip schema
 
       - name: Upload wheel and JSON schemas to GitHub Release
         shell: bash
-        run: gh release upload ${{ github.event.release.tag_name }} *.whl evo-schemas-${{ github.event.release.tag_name }}-schemas.zip
+        run: gh release upload ${{ github.event.release.tag_name }} dist/*


### PR DESCRIPTION
<!--
Thank you for taking the time to make a pull request.

Please review our [contribution guide](https://github.com/seequentevo/evo-samples/blob/main/CONTRIBUTING.md) and our
[code of conduct](https://github.com/seequentevo/evo-samples/blob/main/CONTRIBUTING.md) before opening your first
pull request.

By making a pull request, you confirm you agree to our [Contributor License Agreement (CLA).](https://gist.github.com/imodeljs-admin/9a071844d3a8d420092b5cf360e978ca)
-->

## Description

Ensure the wheels and JSON archives are added to the dist folder, then upload that during releases.

<!-- Describe your proposed changes in detail -->

## Checklist

- [x] I have submitted a Contributor License Agreement
- [x] I have read the contributing guide and the code of conduct
