### PR TITLE
Raw geophysical data schemas V2 - Radiometric + survey-line changes

### DIFF
--- a/objects/time-domain-electromagnetic/2.0.0/time-domain-electromagnetic.schema.json
+++ b/objects/time-domain-electromagnetic/2.0.0/time-domain-electromagnetic.schema.json
@@ -1,0 +1,76 @@
+{
+  "$id": "/objects/time-domain-electromagnetic/2.0.0/time-domain-electromagnetic.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Time Domain Electromagnetic data.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "/components/base-spatial-data-properties/1.1.0/base-spatial-data-properties.schema.json"
+    },
+    {
+      "properties": {
+        "schema": {
+          "const": "/objects/time-domain-electromagnetic/2.0.0/time-domain-electromagnetic.schema.json"
+        },
+        "survey": {
+          "description": "Survey information.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "description": "Survey type.",
+              "type": "string",
+              "enum": [
+                "GROUND",
+                "AIR",
+                "MOVING_GROUND",
+                "DAGCAP"
+              ]
+            }
+          },
+          "required": [
+            "type"
+          ]
+        },
+        "geometry_category": {
+          "description": "Geometry category.",
+          "type": "string",
+          "enum": [
+            "STXMRX",
+            "FGTXRX",
+            "MTXMRX",
+            "STXSRX"
+          ]
+        },
+        "gps": {
+          "description": "Location of GPS relative to point of reference.",
+          "$ref": "/elements/coordinates-3d/1.0.0/coordinates-3d.schema.json"
+        },
+        "channels": {
+          "description": "Channel information.",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "/components/time-domain-electromagnetic-channel/1.0.0/time-domain-electromagnetic-channel.schema.json"
+          }
+        },
+        "line_list": {
+          "description": "Line list.",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "/components/survey-line/2.0.0/survey-line.schema.json"
+          }
+        }
+      }
+    }
+  ],
+  "required": [
+    "schema",
+    "survey",
+    "geometry_category",
+    "gps",
+    "channels",
+    "line_list"
+  ],
+  "unevaluatedProperties": false
+}

--- a/schema/components/channel-attribute-properties/1.0.0/channel-attribute-properties.schema.json
+++ b/schema/components/channel-attribute-properties/1.0.0/channel-attribute-properties.schema.json
@@ -1,0 +1,29 @@
+{
+  "$id": "/components/channel-attribute-properties/1.0.0/channel-attribute-properties.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Common properties for channel attributes in geophysical data.",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "The name of the channel."
+    },
+    "start_fiducial": {
+      "description": "Starting fiducial number.",
+      "type": "number"
+    },
+    "fiducial_increment": {
+      "description": "Fiducial increment amount.",
+      "type": "number",
+      "exclusiveMinimum": 0.0
+    },
+    "significant_digits": {
+      "description": "Significant digits.",
+      "type": "integer",
+      "minimum": 0
+    }
+  },
+  "required": [
+    "name"
+  ]
+}

--- a/schema/components/channel-attribute/2.0.0/channel-attribute.schema.json
+++ b/schema/components/channel-attribute/2.0.0/channel-attribute.schema.json
@@ -1,0 +1,45 @@
+{
+  "$id": "/components/channel-attribute/2.0.0/channel-attribute.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "An attribute for a channel.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "/components/channel-attribute-properties/1.0.0/channel-attribute-properties.schema.json"
+    },
+    {
+      "properties": {
+        "attribute": {
+          "description": "Attribute associated with the channel.",
+          "type": "object",
+          "oneOf": [
+            {
+              "$ref": "/components/bool-attribute/1.1.0/bool-attribute.schema.json"
+            },
+            {
+              "$ref": "/components/continuous-attribute/1.1.0/continuous-attribute.schema.json"
+            },
+            {
+              "$ref": "/components/continuous-ensemble/1.1.0/continuous-ensemble.schema.json"
+            },
+            {
+              "$ref": "/components/category-attribute/1.1.0/category-attribute.schema.json"
+            },
+            {
+              "$ref": "/components/category-ensemble/1.1.0/category-ensemble.schema.json"
+            },
+            {
+              "$ref": "/components/date-time-attribute/1.1.0/date-time-attribute.schema.json"
+            },
+            {
+              "$ref": "/components/string-attribute/1.1.0/string-attribute.schema.json"
+            }
+          ]
+        }
+      },
+      "required": [
+        "attribute"
+      ]
+    }
+  ]
+}

--- a/schema/components/survey-line/2.0.0/survey-line.schema.json
+++ b/schema/components/survey-line/2.0.0/survey-line.schema.json
@@ -1,0 +1,88 @@
+{
+  "$id": "/components/survey-line/2.0.0/survey-line.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "A survey line with coordinates as first-class properties.",
+  "type": "object",
+  "properties": {
+    "line_number": {
+      "description": "The number of the line, can be alphanumeric.",
+      "type": "string"
+    },
+    "date": {
+      "description": "Date.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "version": {
+      "description": "Version.",
+      "type": "integer",
+      "default": 0,
+      "minimum": 0
+    },
+    "group": {
+      "description": "Represents the group when the data is collected.",
+      "type": "integer",
+      "default": 0,
+      "minimum": 0
+    },
+    "type": {
+      "description": "Survey line type.",
+      "enum": [
+        "Line",
+        "Base",
+        "Tie",
+        "Trend",
+        "Special",
+        "Random",
+        "Test"
+      ],
+      "type": "string",
+      "default": "Line"
+    },
+    "coordinates": {
+      "type": "object",
+      "description": "First-class survey location coordinates.",
+      "allOf": [
+        {
+          "$ref": "/components/channel-attribute-properties/1.0.0/channel-attribute-properties.schema.json"
+        },
+        {
+          "properties": {
+            "name": {
+              "const": "coordinates"
+            },
+            "attribute_type": {
+              "const": "ensemble_continuous"
+            },
+            "nan_description": {
+              "description": "Describes the values used to designate not-a-number.",
+              "$ref": "/components/nan-continuous/1.0.1/nan-continuous.schema.json"
+            },
+            "values": {
+              "description": "Array of coordinate values. Each element is an array of 3 floats [x, y, z].",
+              "$ref": "/elements/float-array-3/1.0.1/float-array-3.schema.json"
+            }
+          },
+          "required": [
+            "attribute_type",
+            "nan_description",
+            "values"
+          ]
+        }
+      ]
+    },
+    "channel_attributes": {
+      "title": "List of Channel Attributes",
+      "description": "List of channel attributes.",
+      "type": "array",
+      "items": {
+        "$ref": "/components/channel-attribute/2.0.0/channel-attribute.schema.json"
+      }
+    }
+  },
+  "required": [
+    "line_number",
+    "type",
+    "channel_attributes"
+  ]
+}

--- a/schema/geoscience-objects.schema.json
+++ b/schema/geoscience-objects.schema.json
@@ -41,6 +41,9 @@
       "$ref": "/objects/frequency-domain-electromagnetic/1.1.0/frequency-domain-electromagnetic.schema.json"
     },
     {
+      "$ref": "/objects/frequency-domain-electromagnetic/2.0.0/frequency-domain-electromagnetic.schema.json"
+    },
+    {
       "$ref": "/objects/geological-model-meshes/1.0.1/geological-model-meshes.schema.json"
     },
     {
@@ -87,6 +90,9 @@
     },
     {
       "$ref": "/objects/gravity/1.2.0/gravity.schema.json"
+    },
+    {
+      "$ref": "/objects/gravity/2.0.0/gravity.schema.json"
     },
     {
       "$ref": "/objects/line-segments/1.0.1/line-segments.schema.json"
@@ -137,6 +143,9 @@
       "$ref": "/objects/magnetics/1.2.0/magnetics.schema.json"
     },
     {
+      "$ref": "/objects/magnetics/2.0.0/magnetics.schema.json"
+    },
+    {
       "$ref": "/objects/non-parametric-continuous-cumulative-distribution/1.0.1/non-parametric-continuous-cumulative-distribution.schema.json"
     },
     {
@@ -177,6 +186,9 @@
     },
     {
       "$ref": "/objects/radiometric/1.2.0/radiometric.schema.json"
+    },
+    {
+      "$ref": "/objects/radiometric/2.0.0/radiometric.schema.json"
     },
     {
       "$ref": "/objects/regular-2d-grid/1.0.1/regular-2d-grid.schema.json"
@@ -249,6 +261,9 @@
     },
     {
       "$ref": "/objects/time-domain-electromagnetic/1.1.0/time-domain-electromagnetic.schema.json"
+    },
+    {
+      "$ref": "/objects/time-domain-electromagnetic/2.0.0/time-domain-electromagnetic.schema.json"
     },
     {
       "$ref": "/objects/triangle-mesh/1.0.1/triangle-mesh.schema.json"

--- a/schema/objects/frequency-domain-electromagnetic/2.0.0/frequency-domain-electromagnetic.schema.json
+++ b/schema/objects/frequency-domain-electromagnetic/2.0.0/frequency-domain-electromagnetic.schema.json
@@ -1,0 +1,62 @@
+{
+  "$id": "/objects/frequency-domain-electromagnetic/2.0.0/frequency-domain-electromagnetic.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Frequency Domain Electromagnetic data.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "/components/base-spatial-data-properties/1.1.0/base-spatial-data-properties.schema.json"
+    },
+    {
+      "properties": {
+        "schema": {
+          "const": "/objects/frequency-domain-electromagnetic/2.0.0/frequency-domain-electromagnetic.schema.json"
+        },
+        "survey": {
+          "description": "Survey information.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "description": "Survey type.",
+              "type": "string",
+              "enum": [
+                "GROUND",
+                "AIR"
+              ]
+            }
+          },
+          "required": [
+            "type"
+          ]
+        },
+        "data_type": {
+          "description": "Data type.",
+          "type": "string"
+        },
+        "channels": {
+          "description": "Channel information.",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "/components/frequency-domain-electromagnetic-channel/1.0.0/frequency-domain-electromagnetic-channel.schema.json"
+          }
+        },
+        "line_list": {
+          "description": "Line list.",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "/components/survey-line/2.0.0/survey-line.schema.json"
+          }
+        }
+      }
+    }
+  ],
+  "required": [
+    "schema",
+    "survey",
+    "channels",
+    "line_list"
+  ],
+  "unevaluatedProperties": false
+}

--- a/schema/objects/gravity/2.0.0/gravity.schema.json
+++ b/schema/objects/gravity/2.0.0/gravity.schema.json
@@ -1,0 +1,90 @@
+{
+  "$id": "/objects/gravity/2.0.0/gravity.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Gravity survey data.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "/components/base-spatial-data-properties/1.1.0/base-spatial-data-properties.schema.json"
+    },
+    {
+      "properties": {
+        "schema": {
+          "const": "/objects/gravity/2.0.0/gravity.schema.json"
+        },
+        "type": {
+          "description": "Survey mode.",
+          "type": "string",
+          "enum": [
+            "GROUND",
+            "AIR",
+            "MARINE"
+          ]
+        },
+        "survey_type": {
+          "description": "Type of survey.",
+          "type": "string",
+          "enum": [
+            "GRAV",
+            "FTG",
+            "AGG"
+          ]
+        },
+        "base_stations": {
+          "type": "array",
+          "description": "Base stations.",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "description": "Base station.",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Base station name."
+              },
+              "location": {
+                "type": "array",
+                "description": "Base station location, (x, y, z)-triple.",
+                "maxItems": 3,
+                "minItems": 3,
+                "items": {
+                  "type": "number"
+                }
+              },
+              "gravity_line_list": {
+                "description": "Base station gravity line list.",
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "description": "Gravity survey line.",
+                  "$ref": "/components/survey-line/2.0.0/survey-line.schema.json"
+                }
+              }
+            },
+            "required": [
+              "name",
+              "location",
+              "gravity_line_list"
+            ]
+          }
+        },
+        "gravity_line_list": {
+          "description": "Gravity line list.",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "description": "Gravity survey line.",
+            "$ref": "/components/survey-line/2.0.0/survey-line.schema.json"
+          }
+        }
+      }
+    }
+  ],
+  "required": [
+    "schema",
+    "type",
+    "survey_type",
+    "gravity_line_list"
+  ],
+  "unevaluatedProperties": false
+}

--- a/schema/objects/magnetics/2.0.0/magnetics.schema.json
+++ b/schema/objects/magnetics/2.0.0/magnetics.schema.json
@@ -1,0 +1,128 @@
+{
+  "$id": "/objects/magnetics/2.0.0/magnetics.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Magnetics survey data.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "/components/base-spatial-data-properties/1.1.0/base-spatial-data-properties.schema.json"
+    },
+    {
+      "properties": {
+        "schema": {
+          "const": "/objects/magnetics/2.0.0/magnetics.schema.json"
+        },
+        "type": {
+          "description": "Survey mode.",
+          "type": "string",
+          "enum": [
+            "GROUND",
+            "AIR",
+            "MARINE"
+          ]
+        },
+        "survey_type": {
+          "description": "Type of survey.",
+          "type": "string",
+          "enum": [
+            "TMI",
+            "VMG",
+            "MGRM"
+          ]
+        },
+        "gradient_magnetic": {
+          "type": "object",
+          "description": "Gradient magnetic details.",
+          "properties": {
+            "number_of_sensors": {
+              "type": "integer",
+              "description": "Number of sensors.",
+              "minimum": 1,
+              "default": 1
+            },
+            "sensor_offsets": {
+              "type": "array",
+              "description": "Sensor offsets.",
+              "items": {
+                "type": "array",
+                "description": "Offset location, (x, y, z)-triple.",
+                "minItems": 3,
+                "maxItems": 3,
+                "items": {
+                  "type": "number"
+                }
+              }
+            }
+          },
+          "required": [
+            "number_of_sensors",
+            "sensor_offsets"
+          ]
+        },
+        "base_stations": {
+          "type": "array",
+          "description": "Base stations.",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "description": "Base station.",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Base station name."
+              },
+              "location": {
+                "type": "array",
+                "description": "Base station location, (x, y, z)-triple.",
+                "maxItems": 3,
+                "minItems": 3,
+                "items": {
+                  "type": "number"
+                }
+              },
+              "survey_type": {
+                "description": "Type of survey.",
+                "type": "string",
+                "enum": [
+                  "TMI",
+                  "VMG"
+                ]
+              },
+              "magnetic_line_list": {
+                "description": "Base station magnetic line list.",
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "description": "Magnetic survey line.",
+                  "$ref": "/components/survey-line/2.0.0/survey-line.schema.json"
+                }
+              }
+            },
+            "required": [
+              "name",
+              "location",
+              "survey_type",
+              "magnetic_line_list"
+            ]
+          }
+        },
+        "magnetic_line_list": {
+          "description": "Magnetic line list.",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "description": "Magnetic survey line.",
+            "$ref": "/components/survey-line/2.0.0/survey-line.schema.json"
+          }
+        }
+      }
+    }
+  ],
+  "required": [
+    "schema",
+    "type",
+    "survey_type",
+    "magnetic_line_list"
+  ],
+  "unevaluatedProperties": false
+}

--- a/schema/objects/radiometric/2.0.0/radiometric.schema.json
+++ b/schema/objects/radiometric/2.0.0/radiometric.schema.json
@@ -1,0 +1,67 @@
+{
+  "$id": "/objects/radiometric/2.0.0/radiometric.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Radiometric survey data.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "/components/base-spatial-data-properties/1.1.0/base-spatial-data-properties.schema.json"
+    },
+    {
+      "properties": {
+        "schema": {
+          "const": "/objects/radiometric/2.0.0/radiometric.schema.json"
+        },
+        "survey": {
+          "description": "Survey information.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "description": "Survey type.",
+              "type": "string",
+              "enum": [
+                "GROUND",
+                "AIR"
+              ]
+            }
+          },
+          "required": [
+            "type"
+          ]
+        },
+        "sample_time": {
+          "description": "Total time that elapses between each record (msec).",
+          "type": "number",
+          "minimum": 0.0
+        },
+        "array_dimension": {
+          "description": "Array dimension.",
+          "type": "integer",
+          "minimum": 1,
+          "default": 1024
+        },
+        "energy_level": {
+          "description": "Energy level (meV) of array elements.",
+          "type": "number",
+          "minimum": 0.0
+        },
+        "line_list": {
+          "description": "Line list.",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "/components/survey-line/2.0.0/survey-line.schema.json"
+          }
+        }
+      }
+    }
+  ],
+  "required": [
+    "schema",
+    "survey",
+    "array_dimension",
+    "line_list",
+    "sample_time"
+  ],
+  "unevaluatedProperties": false
+}


### PR DESCRIPTION
- create a new component: channel-attribute-properties to define channel metadata;
- channel-attribute (2.0.0): reference new properties component;
- update geoscience-objects with new v2 schemas;
- survey-line (2.0.0): reduce field requirements;
- radiometric (2.0.0): remove idle_time, live_time, dead_time.

<!--
Thank you for taking the time to make a pull request.

Please review our [contribution guide](https://github.com/seequentevo/evo-samples/blob/main/CONTRIBUTING.md) and our
[code of conduct](https://github.com/seequentevo/evo-samples/blob/main/CONTRIBUTING.md) before opening your first
pull request.

By making a pull request, you confirm you agree to our [Contributor License Agreement (CLA).](https://gist.github.com/imodeljs-admin/9a071844d3a8d420092b5cf360e978ca)
-->

## Description

> [!NOTE]
> The following PR contains prospective changes to the "raw geophysical data" schemas. I am currently in the process of consulting over these proposed changes and will migrate the draft to a full pull request once that consultation is complete.

Relates to the following RFC from the upstream repository: https://github.com/SeequentEvo/evo-schemas/issues/25

## Checklist

- [ ] I have read the contributing guide and the code of conduct
