### PR TITLE
Add block-model schema

### DIFF
--- a/examples/1.0.0/components/block-model-attribute.json
+++ b/examples/1.0.0/components/block-model-attribute.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "/components/block-model-attribute/1.0.0/block-model-attribute.schema.json",
+  "name": "AU",
+  "key": "f1b1a3b0-1b9b-4b6c-9b6b-3b4f1d2b0b0b",
+  "attribute_type": "Float32",
+  "block_model_column_uuid": "f1b1a3b0-1b9b-4b6c-9b6b-3b4f1d2b0b0b",
+  "attribute_description": {
+    "discipline": "Geochemistry",
+    "type": "Gold",
+    "unit": "%"
+  }
+}

--- a/examples/1.0.0/components/block-model-category-attribute.json
+++ b/examples/1.0.0/components/block-model-category-attribute.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "/components/block-model-category-attribute/1.0.0/block-model-category-attribute.schema.json",
+  "name": "Rock",
+  "key": "f1b1a3b0-1b9b-4b6c-9b6b-3b4f1d2b0b0b",
+  "attribute_type": "Utf8",
+  "block_model_column_uuid": "f1b1a3b0-1b9b-4b6c-9b6b-3b4f1d2b0b0b",
+  "attribute_description": {
+    "discipline": "Geology",
+    "type": "Lithology"
+  }
+}

--- a/examples/1.0.0/components/block-model-flexible-structure.json
+++ b/examples/1.0.0/components/block-model-flexible-structure.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "/components/block-model-flexible-structure/1.0.0/block-model-flexible-structure.schema.json",
+  "model_type": "flexible",
+  "origin": [
+    0.0,
+    0.0,
+    0.0
+  ],
+  "n_parent_blocks": [
+    10,
+    10,
+    20
+  ],
+  "parent_block_size": [
+    1.5,
+    1.5,
+    2.5
+  ],
+  "n_subblocks_per_parent": [
+    15,
+    64,
+    21
+  ],
+  "rotation": {
+    "dip_azimuth": 90.0,
+    "dip": 45.0,
+    "pitch": 15.0
+  }
+}

--- a/examples/1.0.0/components/block-model-fully-subblocked-structure.json
+++ b/examples/1.0.0/components/block-model-fully-subblocked-structure.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "/components/block-model-fully-subblocked-structure/1.0.0/block-model-fully-subblocked-structure.schema.json",
+  "model_type": "fully-sub-blocked",
+  "origin": [
+    0.0,
+    0.0,
+    0.0
+  ],
+  "n_parent_blocks": [
+    10,
+    10,
+    20
+  ],
+  "parent_block_size": [
+    1.5,
+    1.5,
+    2.5
+  ],
+  "n_subblocks_per_parent": [
+    8,
+    20,
+    15
+  ],
+  "rotation": {
+    "dip_azimuth": 270.0,
+    "dip": 5.0,
+    "pitch": 150.0
+  }
+}

--- a/examples/1.0.0/components/block-model-regular-structure.json
+++ b/examples/1.0.0/components/block-model-regular-structure.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "/components/block-model-regular-structure/1.0.0/block-model-regular-structure.schema.json",
+  "model_type": "regular",
+  "origin": [
+    0.0,
+    0.0,
+    0.0
+  ],
+  "n_blocks": [
+    10,
+    10,
+    20
+  ],
+  "block_size": [
+    1.5,
+    1.5,
+    2.5
+  ],
+  "rotation": {
+    "dip_azimuth": 91.0,
+    "dip": 14.5,
+    "pitch": 11.0
+  }
+}

--- a/examples/1.0.0/components/block-model-variable-octree-structure.json
+++ b/examples/1.0.0/components/block-model-variable-octree-structure.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "/components/block-model-variable-octree-structure/1.0.0/block-model-variable-octree-structure.schema.json",
+  "model_type": "variable-octree",
+  "origin": [
+    0.0,
+    0.0,
+    0.0
+  ],
+  "n_parent_blocks": [
+    10,
+    10,
+    20
+  ],
+  "parent_block_size": [
+    1.5,
+    1.5,
+    2.5
+  ],
+  "n_subblocks_per_parent": [
+    8,
+    64,
+    1
+  ],
+  "rotation": {
+    "dip_azimuth": 9.0,
+    "dip": 4.5,
+    "pitch": 151.0
+  }
+}

--- a/examples/1.0.0/objects/block-model-1.json
+++ b/examples/1.0.0/objects/block-model-1.json
@@ -1,0 +1,57 @@
+{
+  "schema": "/objects/block-model/1.0.0/block-model.schema.json",
+  "name": "Example Block Model",
+  "uuid": "00000000-0000-0000-0000-000000000000",
+  "description": "This is example data to ensure the object validates properly.",
+  "bounding_box": {
+    "min_x": 0,
+    "max_x": 15,
+    "min_y": 0,
+    "max_y": 15,
+    "min_z": 0,
+    "max_z": 50.0
+  },
+  "coordinate_reference_system": {
+    "epsg_code": 1024
+  },
+  "block_model_uuid": "00000000-0000-0000-0000-000000000001",
+  "block_model_version_uuid": "00000000-0000-0000-0000-000000000002",
+  "geometry": {
+    "model_type": "regular",
+    "origin": [
+      0.0,
+      0.0,
+      0.0
+    ],
+    "n_blocks": [
+      10,
+      10,
+      20
+    ],
+    "block_size": [
+      1.5,
+      1.5,
+      2.5
+    ],
+    "rotation": {
+      "dip_azimuth": 0.0,
+      "dip": 0.0,
+      "pitch": 0.0
+    }
+  },
+  "attributes": [
+    {
+      "name": "AU",
+      "key": "00000000-0000-0000-0000-000000000003",
+      "block_model_column_uuid": "00000000-0000-0000-0000-000000000003",
+      "attribute_type": "Float16",
+      "attribute_description": {
+        "discipline": "Geochemistry",
+        "type": "Gold",
+        "unit": "%"
+      }
+    }
+  ],
+  "tags": {},
+  "extensions": {}
+}

--- a/examples/1.0.0/objects/block-model-2.json
+++ b/examples/1.0.0/objects/block-model-2.json
@@ -1,0 +1,57 @@
+{
+  "schema": "/objects/block-model/1.0.0/block-model.schema.json",
+  "name": "Example Block Model",
+  "uuid": "00000000-0000-0000-0000-000000000001",
+  "description": "This is example data to ensure the object validates properly.",
+  "bounding_box": {
+    "min_x": 0,
+    "max_x": 15,
+    "min_y": 0,
+    "max_y": 15,
+    "min_z": 0,
+    "max_z": 50.0
+  },
+  "coordinate_reference_system": {
+    "epsg_code": 1024
+  },
+  "block_model_uuid": "00000000-0000-0000-0000-000000000002",
+  "block_model_version_uuid": "00000000-0000-0000-0000-000000000004",
+  "geometry": {
+    "model_type": "flexible",
+    "origin": [
+      0.0,
+      0.0,
+      0.0
+    ],
+    "n_parent_blocks": [
+      10,
+      10,
+      20
+    ],
+    "parent_block_size": [
+      1.5,
+      1.5,
+      2.5
+    ],
+    "n_subblocks_per_parent": [
+      15,
+      64,
+      21
+    ],
+    "rotation": {
+      "dip_azimuth": 90.0,
+      "dip": 45.0,
+      "pitch": 15.0
+    }
+  },
+  "attributes": [
+    {
+      "name": "example_attr",
+      "key": "00000000-0000-0000-0000-000000000004",
+      "block_model_column_uuid": "00000000-0000-0000-0000-000000000004",
+      "attribute_type": "Boolean"
+    }
+  ],
+  "tags": {},
+  "extensions": {}
+}

--- a/examples/1.0.0/objects/block-model-3.json
+++ b/examples/1.0.0/objects/block-model-3.json
@@ -1,0 +1,57 @@
+{
+  "schema": "/objects/block-model/1.0.0/block-model.schema.json",
+  "name": "Example Block Model",
+  "uuid": "00000000-0000-0000-0000-000000000002",
+  "description": "This is example data to ensure the object validates properly.",
+  "bounding_box": {
+    "min_x": 0,
+    "max_x": 15,
+    "min_y": 0,
+    "max_y": 15,
+    "min_z": 0,
+    "max_z": 50.0
+  },
+  "coordinate_reference_system": {
+    "epsg_code": 1024
+  },
+  "block_model_uuid": "00000000-0000-0000-0000-000000000003",
+  "block_model_version_uuid": "00000000-0000-0000-0000-000000000008",
+  "geometry": {
+    "model_type": "fully-sub-blocked",
+    "origin": [
+      0.0,
+      0.0,
+      0.0
+    ],
+    "n_parent_blocks": [
+      10,
+      10,
+      20
+    ],
+    "parent_block_size": [
+      1.5,
+      1.5,
+      2.5
+    ],
+    "n_subblocks_per_parent": [
+      8,
+      20,
+      15
+    ],
+    "rotation": {
+      "dip_azimuth": 270.0,
+      "dip": 5.0,
+      "pitch": 150.0
+    }
+  },
+  "attributes": [
+    {
+      "name": "example_attr",
+      "key": "00000000-0000-0000-0000-000000000016",
+      "block_model_column_uuid": "00000000-0000-0000-0000-000000000016",
+      "attribute_type": "Utf8"
+    }
+  ],
+  "tags": {},
+  "extensions": {}
+}

--- a/examples/1.0.0/objects/block-model-4.json
+++ b/examples/1.0.0/objects/block-model-4.json
@@ -1,0 +1,57 @@
+{
+  "schema": "/objects/block-model/1.0.0/block-model.schema.json",
+  "name": "Example Block Model",
+  "uuid": "00000000-0000-0000-0000-000000000003",
+  "description": "This is example data to ensure the object validates properly.",
+  "bounding_box": {
+    "min_x": 0,
+    "max_x": 15,
+    "min_y": 0,
+    "max_y": 15,
+    "min_z": 0,
+    "max_z": 50.0
+  },
+  "coordinate_reference_system": {
+    "epsg_code": 1024
+  },
+  "block_model_uuid": "00000000-0000-0000-0000-000000000004",
+  "block_model_version_uuid": "00000000-0000-0000-0000-000000000016",
+  "geometry": {
+    "model_type": "variable-octree",
+    "origin": [
+      0.0,
+      0.0,
+      0.0
+    ],
+    "n_parent_blocks": [
+      10,
+      10,
+      20
+    ],
+    "parent_block_size": [
+      1.5,
+      1.5,
+      2.5
+    ],
+    "n_subblocks_per_parent": [
+      8,
+      16,
+      4
+    ],
+    "rotation": {
+      "dip_azimuth": 70.0,
+      "dip": 50.0,
+      "pitch": 1.0
+    }
+  },
+  "attributes": [
+    {
+      "name": "example_attr",
+      "key": "00000000-0000-0000-0000-000000000032",
+      "block_model_column_uuid": "00000000-0000-0000-0000-000000000032",
+      "attribute_type": "Date32"
+    }
+  ],
+  "tags": {},
+  "extensions": {}
+}

--- a/schema/components/block-model-attribute/1.0.0/block-model-attribute.schema.json
+++ b/schema/components/block-model-attribute/1.0.0/block-model-attribute.schema.json
@@ -1,0 +1,42 @@
+{
+  "$id": "/components/block-model-attribute/1.0.0/block-model-attribute.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "A block model attribute.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "/components/base-continuous-attribute/1.0.0/base-continuous-attribute.schema.json"
+    },
+    {
+      "properties": {
+        "attribute_type": {
+          "description": "The data type of the attribute as stored in the Block Model Service.",
+          "enum": [
+            "Int8",
+            "Int16",
+            "Int32",
+            "Int64",
+            "UInt8",
+            "UInt16",
+            "UInt32",
+            "UInt64",
+            "Float16",
+            "Float32",
+            "Float64",
+            "Date32",
+            "Timestamp"
+          ]
+        },
+        "block_model_column_uuid": {
+          "description": "The unique ID of the attribute on the block model.",
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    }
+  ],
+  "required": [
+    "attribute_type",
+    "block_model_column_uuid"
+  ]
+}

--- a/schema/components/block-model-category-attribute/1.0.0/block-model-category-attribute.schema.json
+++ b/schema/components/block-model-category-attribute/1.0.0/block-model-category-attribute.schema.json
@@ -1,0 +1,31 @@
+{
+  "$id": "/components/block-model-category-attribute/1.0.0/block-model-category-attribute.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "A block model category/string attribute stored by the Block Model Service.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "/components/base-category-attribute/1.0.0/base-category-attribute.schema.json"
+    },
+    {
+      "properties": {
+        "attribute_type": {
+          "description": "The data type of the attribute as stored in the Block Model Service.",
+          "enum": [
+            "Boolean",
+            "Utf8"
+          ]
+        },
+        "block_model_column_uuid": {
+          "description": "The unique ID of the attribute on the block model.",
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    }
+  ],
+  "required": [
+    "attribute_type",
+    "block_model_column_uuid"
+  ]
+}

--- a/schema/components/block-model-flexible-structure/1.0.0/block-model-flexible-structure.schema.json
+++ b/schema/components/block-model-flexible-structure/1.0.0/block-model-flexible-structure.schema.json
@@ -1,0 +1,65 @@
+{
+  "$id": "/components/block-model-flexible-structure/1.0.0/block-model-flexible-structure.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "The structure of a flexibly-subblocked block model. Subblocking is carried out by dividing each parent block into a fixed grid of subblocks defined by n_subblocks_per_parent, before recombining the subblocks into larger chunks. The resulting subblocks can have different sizes within the same parent block, but must remain cuboid and completely fill the parent block.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "model_type": {
+      "description": "The model geometry type.",
+      "type": "string",
+      "const": "flexible"
+    },
+    "n_parent_blocks": {
+      "description": "The number of parent blocks in the model. [nx, ny, nz]",
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "integer",
+        "minimum": 1
+      }
+    },
+    "parent_block_size": {
+      "description": "The size of each parent block in the model. [dx, dy, dz]",
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "number",
+        "exclusiveMinimum": 0
+      }
+    },
+    "n_subblocks_per_parent": {
+      "description": "The number of blocks per axis in the underlying subblock grid in each parent block in the model. [nx, ny, nz]",
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 100
+      }
+    },
+    "origin": {
+      "description": "The coordinates of the model origin. [x, y, z]",
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "number"
+      }
+    },
+    "rotation": {
+      "description": "The orientation of the model.",
+      "$ref": "/components/rotation/1.1.0/rotation.schema.json"
+    }
+  },
+  "required": [
+    "model_type",
+    "n_parent_blocks",
+    "parent_block_size",
+    "n_subblocks_per_parent",
+    "origin"
+  ]
+}

--- a/schema/components/block-model-fully-subblocked-structure/1.0.0/block-model-fully-subblocked-structure.schema.json
+++ b/schema/components/block-model-fully-subblocked-structure/1.0.0/block-model-fully-subblocked-structure.schema.json
@@ -1,0 +1,65 @@
+{
+  "$id": "/components/block-model-fully-subblocked-structure/1.0.0/block-model-fully-subblocked-structure.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "The structure of a fully-subblocked block model. Subblocking is carried out by either splitting a parent block into exactly the grid defined by n_subblocks_per_parent, or leaving it whole.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "model_type": {
+      "description": "The model geometry type.",
+      "type": "string",
+      "const": "fully-sub-blocked"
+    },
+    "n_parent_blocks": {
+      "description": "The number of parent blocks in the model. [nx, ny, nz]",
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "integer",
+        "minimum": 1
+      }
+    },
+    "parent_block_size": {
+      "description": "The size of each parent block in the model. [dx, dy, dz]",
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "number",
+        "exclusiveMinimum": 0
+      }
+    },
+    "n_subblocks_per_parent": {
+      "description": "The number of subblocks in each subblocked parent block in the model in each axis. [nx, ny, nz]",
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 100
+      }
+    },
+    "origin": {
+      "description": "The coordinates of the model origin. [x, y, z]",
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "number"
+      }
+    },
+    "rotation": {
+      "description": "The orientation of the model.",
+      "$ref": "/components/rotation/1.1.0/rotation.schema.json"
+    }
+  },
+  "required": [
+    "model_type",
+    "n_parent_blocks",
+    "parent_block_size",
+    "n_subblocks_per_parent",
+    "origin"
+  ]
+}

--- a/schema/components/block-model-regular-structure/1.0.0/block-model-regular-structure.schema.json
+++ b/schema/components/block-model-regular-structure/1.0.0/block-model-regular-structure.schema.json
@@ -1,0 +1,53 @@
+{
+  "$id": "/components/block-model-regular-structure/1.0.0/block-model-regular-structure.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "The structure of a regular, non-subblocked block model.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "model_type": {
+      "description": "The model geometry type.",
+      "type": "string",
+      "const": "regular"
+    },
+    "n_blocks": {
+      "description": "The number of blocks in the model. [nx, ny, nz]",
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "integer",
+        "minimum": 1
+      }
+    },
+    "block_size": {
+      "description": "The size of each block in the model. [dx, dy, dz]",
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "number",
+        "exclusiveMinimum": 0
+      }
+    },
+    "origin": {
+      "description": "The coordinates of the model origin. [x, y, z]",
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "number"
+      }
+    },
+    "rotation": {
+      "description": "The orientation of the model.",
+      "$ref": "/components/rotation/1.1.0/rotation.schema.json"
+    }
+  },
+  "required": [
+    "model_type",
+    "n_blocks",
+    "block_size",
+    "origin"
+  ]
+}

--- a/schema/components/block-model-variable-octree-structure/1.0.0/block-model-variable-octree-structure.schema.json
+++ b/schema/components/block-model-variable-octree-structure/1.0.0/block-model-variable-octree-structure.schema.json
@@ -1,0 +1,72 @@
+{
+  "$id": "/components/block-model-variable-octree-structure/1.0.0/block-model-variable-octree-structure.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "The structure of a variable-octree subblocked model. Subblocking is carried out by repeatedly splitting blocks along each axis, until there are a maximum of n_subblocks_per_parent subblocks. This number can be different per axis.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "model_type": {
+      "description": "The model geometry type.",
+      "type": "string",
+      "const": "variable-octree"
+    },
+    "n_parent_blocks": {
+      "description": "The number of parent blocks in the model. [nx, ny, nz]",
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "integer",
+        "minimum": 1
+      }
+    },
+    "parent_block_size": {
+      "description": "The size of each parent block in the model. [dx, dy, dz]",
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "number",
+        "exclusiveMinimum": 0
+      }
+    },
+    "n_subblocks_per_parent": {
+      "description": "The maximum number of subblocks in each parent block in the model in each axis. [nx, ny, nz]",
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "integer",
+        "enum": [
+          1,
+          2,
+          4,
+          8,
+          16,
+          32,
+          64
+        ]
+      }
+    },
+    "origin": {
+      "description": "The coordinates of the model origin. [x, y, z]",
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "number"
+      }
+    },
+    "rotation": {
+      "description": "The orientation of the model.",
+      "$ref": "/components/rotation/1.1.0/rotation.schema.json"
+    }
+  },
+  "required": [
+    "model_type",
+    "n_parent_blocks",
+    "parent_block_size",
+    "n_subblocks_per_parent",
+    "origin"
+  ]
+}

--- a/schema/geoscience-objects.schema.json
+++ b/schema/geoscience-objects.schema.json
@@ -5,6 +5,9 @@
   "type": "object",
   "oneOf": [
     {
+      "$ref": "/objects/block-model/1.0.0/block-model.schema.json"
+    },
+    {
       "$ref": "/objects/design-geometry/1.0.1/design-geometry.schema.json"
     },
     {

--- a/schema/objects/block-model/1.0.0/block-model.schema.json
+++ b/schema/objects/block-model/1.0.0/block-model.schema.json
@@ -1,0 +1,65 @@
+{
+  "$id": "/objects/block-model/1.0.0/block-model.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "A reference to a block model stored in the Block Model Service.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "/components/base-spatial-data-properties/1.1.0/base-spatial-data-properties.schema.json"
+    },
+    {
+      "properties": {
+        "schema": {
+          "const": "/objects/block-model/1.0.0/block-model.schema.json"
+        },
+        "block_model_uuid": {
+          "description": "The unique ID of the block model in the Block Model Service.",
+          "type": "string",
+          "format": "uuid"
+        },
+        "block_model_version_uuid": {
+          "description": "The unique ID of this version of the block model in the Block Model Service.",
+          "type": "string",
+          "format": "uuid"
+        },
+        "geometry": {
+          "description": "The geometry (including subblocking parameters, if applicable) of the block model.",
+          "oneOf": [
+            {
+              "$ref": "/components/block-model-flexible-structure/1.0.0/block-model-flexible-structure.schema.json"
+            },
+            {
+              "$ref": "/components/block-model-fully-subblocked-structure/1.0.0/block-model-fully-subblocked-structure.schema.json"
+            },
+            {
+              "$ref": "/components/block-model-regular-structure/1.0.0/block-model-regular-structure.schema.json"
+            },
+            {
+              "$ref": "/components/block-model-variable-octree-structure/1.0.0/block-model-variable-octree-structure.schema.json"
+            }
+          ]
+        },
+        "attributes": {
+          "description": "The attributes found on this version of the block model.",
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "/components/block-model-attribute/1.0.0/block-model-attribute.schema.json"
+              },
+              {
+                "$ref": "/components/block-model-category-attribute/1.0.0/block-model-category-attribute.schema.json"
+              }
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "required": [
+    "schema",
+    "block_model_uuid",
+    "geometry"
+  ],
+  "unevaluatedProperties": false
+}


### PR DESCRIPTION
<!--
Thank you for taking the time to make a pull request.

Please review our [contribution guide](https://github.com/seequentevo/evo-samples/blob/main/CONTRIBUTING.md) and our
[code of conduct](https://github.com/seequentevo/evo-samples/blob/main/CONTRIBUTING.md) before opening your first
pull request.

By making a pull request, you confirm you agree to our [Contributor License Agreement (CLA).](https://gist.github.com/imodeljs-admin/9a071844d3a8d420092b5cf360e978ca)
-->

## Description

We have recently finalised the schema design for BlockSync's [block model reference objects](https://developer.seequent.com/docs/guides/blockmodel/general-usage/reference-objects), which are used to represent block models whose metadata and data is stored in the Block Model Service.

> [!NOTE]
> This schema is already in place internally; this PR makes that internal implementation public.

- New object: `block-model`
- New components:
  - `block-model-attribute`, `block-model-category-attribute`
  - `block-model-regular-structure`, `block-model-fully-subblocked-structure`, `block-model-variable-octree-structure`, `block-model-flexible-structure`
- Examples of the above

## Checklist

- [x] I have read the contributing guide and the code of conduct
