### PR TITLE
Exp variogram object

### DIFF
--- a/docs/schemas/experimental-variogram.md
+++ b/docs/schemas/experimental-variogram.md
@@ -1,0 +1,88 @@
+import OverlineWithVersion from '@theme/OverlineWithVersion';
+import SchemaUri from '@theme/SchemaUri';
+import FlatProperties from './_generated/flatmd/objects/experimental-variogram-1.0.0.md';
+
+<OverlineWithVersion title="Geoscience Objects" version="1.0.0" badge="techPreview" />
+
+# variogram
+
+<SchemaUri uri="schema/objects/experimental-variogram/1.0.0/experimental-variogram.schema.json" />
+
+The experimental-variogram object is used to capture spatial variability of univariate data acorss an area of interest. Spatial variability is described by direction and summarized per each lag in a direction. 
+
+The experimental variogram is calculated a part of a standard variography workflow and is precursor to variogram modeling. An experimental variogram is a key input to fitting a variogram model.
+
+## Required Data
+
+To construct an experimental variogram object the following information is required.
+
+* `data_variance` (number): The variance of the source data
+
+* `directions` (object): Table describing geometry and type of each direction for which lags exist.
+    * `data` (binary blob): Table with columns: offset, count, direction_type, azimuth, dip, azimuth_tolerance, dip_tolerance, bandwidth, bandheight.
+        * `offset` (integer): Index in the lags table at which the information associated with this direction begins
+        * `count` (integer): Number of entries in lag tabl associated with this direction (number of lags).
+        * `direction_type` (string: ["directional", "omnidirectional" or "downhole"]): type of direciton described
+        * `azimuth` (float): Clockwise rotation about the z-axis
+        * `dip` (float): Incline of the direction, negative points down
+        * `azimuth_tolerance` (float): Tolerance considered on either side of the azimuth direction, contributing to the conical definition of the search
+        * `dip_tolerance` (float): Tolcerance considered on either side of the dip, contributing to the conical definition of the search
+        * `bandwidth` (float): Width of the search to be considered once the conical search has reached its extexts
+        * `bandheight` (float): Height of the search to be considered once the conical search has reached its extexts
+    * `length` (integer): Number of directions
+    * `width` (const): Must be 9
+    * `data_type` (const): Must be "uint64/uint64/string/float64/float64/float64/float64/float64/float64"
+
+* `lags` (object): Table describing individual lags
+    * `data`(binary blob): Table with columns: start, end, centroid, value, num_pairs.
+        * `start` (float): start distance of the lag
+        * `end` (float): end distance of the lag
+        * `centroid` (float): average distance (centroid) of all pairs represented in lag
+        * `value` (float) : calculated value representing spatial correlation, semi-variance or other described by the `variogram_type` field.
+        * `num_pairs` (integer): number of pairs considered in the `value` calculation.
+    * `length` (integer): Total number of lag bins
+    * `width` (const): Must be 5
+    * `data_type` (const): Must be "uint64/uint64/float64/float64/float64/float64/uint64"
+    * `directions` (object): Contains:
+
+### Example Tables
+
+Two small examples below demonstrate the defined format of the `directions` and `lags` tables described above.
+
+#### Directions Table
+
+
+| offset | count | direction_type | azimuth | dip | azimuth_tolerance | dip_tolerance | bandwidth | bandheight |
+|:------:|:-----:|:--------------:|:-------:|:---:|:-----------------:|:-------------:|:---------:|:----------:|
+|   0    |  20   |  directional   |    0    |  0  |       22.5        |     22.5      |    50     |     50     |
+|  20    |  20   |  directional   |   90    |  0  |       22.5        |     22.5      |    50     |     50     |
+|  40    |  20   |  directional   |    0    | -90 |       10.0        |     10.0      |    20     |     20     |
+
+
+#### Lags Table
+
+
+start | end | centroid | value | num_pairs
+:--: | :--: | :--: | :--: | :--:
+0.0 | 5.0 | 2.5 | 0.012993 | 33
+5.0 | 10.0 | 7.5 | 0.160659 | 63
+10.0 | 15.0 | 12.5 | 0.313465 | 12
+15.0 | 20.0 | 17.5 | 0.422976 | 43
+20.0 | 25.0 | 22.5 | 0.502526 | 74
+
+## Optional fields include:
+
+* `description` (string)
+* `domain` (string): The domain the variogram is calculated for
+* `attribute` (string): The attribute the variogram is calculated for
+* `variogram_type` (string, default: "variogram"): Type of calculation performed Both lags and directions can also 
+have optional additional attributes through the  attribute-list-property component.
+* `distance_unit` (string): Distance units used to describe `start`, `end` and `centroid` in lag table
+* `attribute_unit` (string): Units of the attribute being described
+
+The schema enforces unevaluatedProperties: false, meaning no additional properties beyond those defined are allowed.
+## Properties
+
+<FlatProperties />
+
+::mermaid[_generated/uml/experimental-variogram-1.0.0.mmd]

--- a/examples/1.0.0/objects/experimental-variogram.json
+++ b/examples/1.0.0/objects/experimental-variogram.json
@@ -1,0 +1,22 @@
+{
+  "schema": "/objects/experimental-variogram/1.0.0/experimental-variogram.schema.json",
+  "name": "Example Experimental Variogram",
+  "uuid": "11111111-1111-1111-1111-111111111111",
+  "description": "Example data for an experimental variogram object, demonstrating spatial continuity statistics for a single variable.",
+  "domain": "Domain-one",
+  "attribute": "porosity",
+  "data_variance": 0.25,
+  "variogram_type": "traditional semi-variogram",
+  "directions": {
+    "data": "abababababababababababababababababababababababababababababababab",
+    "data_type": "uint64/uint64/string/float64/float64/float64/float64/float64/float64",
+    "length": 2,
+    "width": 9
+  },
+  "lags": {
+    "data": "abababababababababababababababababababababababababababababababab",
+    "length": 6,
+    "width": 5,
+    "data_type": "float64/float64/float64/float64/uint64"
+  }
+}

--- a/schema/geoscience-objects.schema.json
+++ b/schema/geoscience-objects.schema.json
@@ -44,6 +44,9 @@
       "$ref": "/objects/drilling-campaign/1.0.0/drilling-campaign.schema.json"
     },
     {
+      "$ref": "/objects/experimental-variogram/1.0.0/experimental-variogram.schema.json"
+    },
+    {
       "$ref": "/objects/frequency-domain-electromagnetic/1.0.0/frequency-domain-electromagnetic.schema.json"
     },
     {

--- a/schema/objects/experimental-variogram/1.0.0/experimental-variogram.schema.json
+++ b/schema/objects/experimental-variogram/1.0.0/experimental-variogram.schema.json
@@ -1,0 +1,125 @@
+{
+  "$id": "/objects/experimental-variogram/1.0.0/experimental-variogram.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Experimental Variogram",
+  "description": "An experimental variogram object representing spatial continuity statistics for a single variable, grouped by direction and lag distance.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "/components/base-object-properties/1.1.0/base-object-properties.schema.json"
+    },
+    {
+      "properties": {
+        "schema": {
+          "const": "/objects/experimental-variogram/1.0.0/experimental-variogram.schema.json"
+        },
+        "domain": {
+          "description": "The domain the experimental variogram is calculated for.",
+          "type": "string"
+        },
+        "attribute": {
+          "description": "The attribute the experimental variogram is calculated for.",
+          "type": "string"
+        },
+        "data_variance": {
+          "description": "The variance of the source data, often used as the expected sill of the variogram.",
+          "type": "number"
+        },
+        "variogram_type": {
+          "description": "The type of calculation performed (e.g., variogram, semi-variogram, covariance, correlogram).",
+          "type": "string",
+          "default": "variogram"
+        },
+        "distance_unit": {
+          "description": "Distance unit.",
+          "$ref": "/elements/unit/1.0.1/categories/unit-length.schema.json"
+        },
+        "attribute_unit": {
+          "description": "Attribute unit",
+          "$ref": "/elements/unit/1.0.1/unit.schema.json"
+        },
+        "directions": {
+          "description": "A data-table defining the parameters for each variogram direction.",
+          "allOf": [
+            {
+              "$ref": "/components/attribute-list-property/1.2.0/attribute-list-property.schema.json",
+              "description": "Optional attributes for each direction, such as a 'name'. The length of each attribute array must match the number of directions."
+            },
+            {
+              "type": "object",
+              "properties": {
+                "data": {
+                  "description": "Binary blob reference for the directions data table. Columns: offset, count, direction_type, azimuth, dip, azimuth_tolerance, dip_tolerance, bandwidth, bandheight.",
+                  "$ref": "/elements/binary-blob/1.0.1/binary-blob.schema.json"
+                },
+                "length": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "description": "Number of directions."
+                },
+                "width": {
+                  "description": "Number of columns in the core directions data table.",
+                  "const": 9
+                },
+                "data_type": {
+                  "description": "Data types for the core directions columns.",
+                  "const": "uint64/uint64/string/float64/float64/float64/float64/float64/float64"
+                }
+              },
+              "required": [
+                "data",
+                "length",
+                "width",
+                "data_type"
+              ]
+            }
+          ]
+        },
+        "lags": {
+          "description": "A data-table containing the calculated values for each lag bin.",
+          "allOf": [
+            {
+              "$ref": "/components/attribute-list-property/1.2.0/attribute-list-property.schema.json",
+              "description": "Optional attributes for each lag bin, such as 'weights'. The length of each attribute array must match the total number of lag bins."
+            },
+            {
+              "type": "object",
+              "properties": {
+                "data": {
+                  "description": "Binary blob reference for the lag data table. The columns must be: start, end, centroid, value, num_pairs.",
+                  "$ref": "/elements/binary-blob/1.0.1/binary-blob.schema.json"
+                },
+                "length": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "description": "Total number of lag bins across all directions."
+                },
+                "width": {
+                  "description": "Number of columns in the core lag data table.",
+                  "const": 5
+                },
+                "data_type": {
+                  "description": "Data types for the core lag data columns.",
+                  "const": "float64/float64/float64/float64/uint64"
+                }
+              },
+              "required": [
+                "data",
+                "length",
+                "width",
+                "data_type"
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "required": [
+    "schema",
+    "directions",
+    "lags",
+    "data_variance"
+  ],
+  "unevaluatedProperties": false
+}

--- a/tools/documentation.py
+++ b/tools/documentation.py
@@ -349,7 +349,7 @@ class SchemaVisualizer:
         """
         parent = None
         lines = []
-        extra_schemas = set()
+        extra_schemas = dict()
         associations = []
         parent_props = defaultdict(list)
         hierarchy = self._get_hierarchy(schema_type)
@@ -381,7 +381,7 @@ class SchemaVisualizer:
                     continue
                 elif isinstance(prop.type, SchemaClass):
                     if render_associations > 0:
-                        extra_schemas.add(self._types[prop.type.id])
+                        extra_schemas[self._types[prop.type.id].id] = self._types[prop.type.id]
                     ref_name = self._make_full_name(prop.type)
                     propline = self._make_mermaid_prop_line(prop.name, ref_name, ref=True)
                     parent_props[schema_ref.id].append(
@@ -414,7 +414,7 @@ class SchemaVisualizer:
             parent = schema_ref
         if render_associations > 0:
             lines.extend(associations)
-        for schema_ref in extra_schemas:
+        for schema_ref in extra_schemas.values():
             sublines = self._generate_mermaid_for_subtree(schema_ref, render_associations - 1, seen=seen)
             lines.extend(sublines)
         return lines
@@ -459,7 +459,7 @@ class SchemaVisualizer:
         """
         parent = None
         lines = []
-        extra_schemas = set()
+        extra_schemas = dict()
         associations = []
         parent_props = defaultdict(list)
         hierarchy = self._get_hierarchy(schema_type)
@@ -498,7 +498,7 @@ class SchemaVisualizer:
                     continue
                 elif isinstance(prop.type, SchemaClass):
                     if render_associations > 0:
-                        extra_schemas.add(self._types[prop.type.id])
+                        extra_schemas[self._types[prop.type.id].id] = self._types[prop.type.id]
                     ref_name = self._make_full_name(prop.type)
                     propline = self._make_plantuml_prop_line(prop.name, ref_name, ref=True)
                     parent_props[schema_ref.id].append(
@@ -531,7 +531,7 @@ class SchemaVisualizer:
             parent = schema_ref
         if render_associations > 0:
             lines.extend(associations)
-        for schema_ref in extra_schemas:
+        for schema_ref in extra_schemas.values():
             sublines = self._generate_plantuml_for_subtree(schema_ref, render_associations - 1, seen=seen)
             lines.extend(sublines)
         return lines


### PR DESCRIPTION
## Description

Add support for experimental variograms via a new object. 
Implementation is described in [the associated RFC](https://github.com/SeequentEvo/evo-schemas/issues/30)

Variogram information is stored in two tables:
1. `lags table` - stores all of the information associated with specific lags such as variogram values, number of pairs etc.
<html>
<body>

direction_id | lag_number | lag_distance | lag_tolerance | start | end | value | num_pairs
-- | -- | -- | -- | -- | -- | -- | --
0 | 0 | 5.0 | 2.5 | 0.0 | 5.0 | 0.043694 | 23
0 | 1 | 5.0 | 2.5 | 5.0 | 10.0 | 0.195290 | 40
0 | 2 | 5.0 | 2.5 | 10.0 | 15.0 | 0.280245 | 83
0 | 3 | 5.0 | 2.5 | 15.0 | 20.0 | 0.434872 | 58
0 | 4 | 5.0 | 2.5 | 20.0 | 25.0 | 0.481286 | 22

</body>
</html>

2. `directions table` - stores geometric information about search parameters for each direction (expect for lag distance and tolerance as those are permitted to vary per lag.

<html>
<body>

direction_id | direction_type | nlags | azimuth | dip | azimuth_tolerance | dip_tolerance | bandwidth | bandheight
-- | -- | -- | -- | -- | -- | -- | -- | --
0 | directional | 20 | 0 | 0 | 22.5 | 22.5 | 50 | 50
1 | directional | 20 | 45 | 0 | 22.5 | 22.5 | 50 | 50
2 | directional | 20 | 0 | -90 | 10.0 | 10.0 | 20 | 20

</body>
</html>

Entries in these tables are linked by `direction_id`.

An example use case:

[exp-variogram-example.ipynb](https://github.com/user-attachments/files/22908592/exp-variogram-example.ipynb)

[exp-variogram-example.html](https://github.com/user-attachments/files/22909271/exp-variogram-example.html)

## Checklist

- [x] I have read the contributing guide and the code of conduct
