### PR TITLE
Make rendering of UML deterministic

### DIFF
--- a/tools/documentation.py
+++ b/tools/documentation.py
@@ -349,7 +349,7 @@ class SchemaVisualizer:
         """
         parent = None
         lines = []
-        extra_schemas = set()
+        extra_schemas = dict()
         associations = []
         parent_props = defaultdict(list)
         hierarchy = self._get_hierarchy(schema_type)
@@ -381,7 +381,7 @@ class SchemaVisualizer:
                     continue
                 elif isinstance(prop.type, SchemaClass):
                     if render_associations > 0:
-                        extra_schemas.add(self._types[prop.type.id])
+                        extra_schemas[self._types[prop.type.id].id] = self._types[prop.type.id]
                     ref_name = self._make_full_name(prop.type)
                     propline = self._make_mermaid_prop_line(prop.name, ref_name, ref=True)
                     parent_props[schema_ref.id].append(
@@ -414,7 +414,7 @@ class SchemaVisualizer:
             parent = schema_ref
         if render_associations > 0:
             lines.extend(associations)
-        for schema_ref in extra_schemas:
+        for schema_ref in extra_schemas.values():
             sublines = self._generate_mermaid_for_subtree(schema_ref, render_associations - 1, seen=seen)
             lines.extend(sublines)
         return lines
@@ -459,7 +459,7 @@ class SchemaVisualizer:
         """
         parent = None
         lines = []
-        extra_schemas = set()
+        extra_schemas = dict()
         associations = []
         parent_props = defaultdict(list)
         hierarchy = self._get_hierarchy(schema_type)
@@ -498,7 +498,7 @@ class SchemaVisualizer:
                     continue
                 elif isinstance(prop.type, SchemaClass):
                     if render_associations > 0:
-                        extra_schemas.add(self._types[prop.type.id])
+                        extra_schemas[self._types[prop.type.id].id] = self._types[prop.type.id]
                     ref_name = self._make_full_name(prop.type)
                     propline = self._make_plantuml_prop_line(prop.name, ref_name, ref=True)
                     parent_props[schema_ref.id].append(
@@ -531,7 +531,7 @@ class SchemaVisualizer:
             parent = schema_ref
         if render_associations > 0:
             lines.extend(associations)
-        for schema_ref in extra_schemas:
+        for schema_ref in extra_schemas.values():
             sublines = self._generate_plantuml_for_subtree(schema_ref, render_associations - 1, seen=seen)
             lines.extend(sublines)
         return lines


### PR DESCRIPTION
## Description

This PR makes the generation of UML diagrams (including Mermaid .mmd files committed in the docs) deterministic across runs.

This is a simple fix that uses a `dict` instead of a `set` to preserve the deduplication handling when generating the list of referenced schemas to recurse over. Because the insertion order is preserved in the `dict`, it ends up consistent across runs.

_NB: I would have preferred to be a little more explicit and just convert to a `list` then sort... but that would require defining sort ordering for the objects in question, which felt much more unnecessarily complex._

## Related

This resolves the generation of spurious changes when committing `.mmd` files into the repo, as seen in https://github.com/SeequentEvo/evo-schemas/pull/42 and https://github.com/SeequentEvo/evo-schemas/pull/40.

## Checklist

- [x] I have read the contributing guide and the code of conduct
