### PR TITLE
Strip nulls from strings.

### DIFF
--- a/tools/code_generator/helpers/python_serialiser.py
+++ b/tools/code_generator/helpers/python_serialiser.py
@@ -180,10 +180,15 @@ class Serialiser:
                     raise cls._validation_error(t, value, name)
                 return result
 
-            case builtins.bool | builtins.str | types.NoneType:
+            case builtins.bool | types.NoneType:
                 if type(value) is not t:
                     raise cls._validation_error(t, value, name)
                 return value
+
+            case builtins.str:
+                if type(value) is not t:
+                    raise cls._validation_error(t, value, name)
+                return value.replace('\0', '')
 
             case uuid.UUID if isinstance(value, uuid.UUID):
                 return value


### PR DESCRIPTION
## Description

Remove all null characters from fields with a string type. Evo allows nulls in data but applications often can't handle them and there's no use case for strings with nulls.

## Checklist

- [x] I have read the contributing guide and the code of conduct
