### PR TITLE
Create new triangle-mesh minor version with optional quality property

### DIFF
--- a/examples/2.3.0/objects/triangle-mesh-1.json
+++ b/examples/2.3.0/objects/triangle-mesh-1.json
@@ -1,0 +1,166 @@
+{
+  "schema": "/objects/triangle-mesh/2.3.0/triangle-mesh.schema.json",
+  "name": "Example Triangle Mesh",
+  "uuid": "00000000-0000-0000-0000-000000000000",
+  "description": "This is example data to ensure triangle mesh validates properly",
+  "bounding_box": {
+    "min_y": 5,
+    "max_y": 10,
+    "min_x": 0,
+    "max_x": 10,
+    "min_z": 5,
+    "max_z": 10
+  },
+  "coordinate_reference_system": {
+    "epsg_code": 1024
+  },
+  "triangles": {
+    "vertices": {
+      "width": 3,
+      "data_type": "float64",
+      "length": 64,
+      "data": "abababababababababababababababababababababababababababababababab",
+      "attributes": [
+        {
+          "name": "lithology",
+          "key": "lith",
+          "attribute_type": "category",
+          "nan_description": {
+            "values": [
+              -99
+            ]
+          },
+          "attribute_description": {
+            "discipline": "Geology",
+            "type": "Rock Type"
+          },
+          "values": {
+            "data_type": "int32",
+            "length": 64,
+            "width": 1,
+            "data": "abababababababababababababababababababababababababababababababab"
+          },
+          "table": {
+            "keys_data_type": "int32",
+            "values_data_type": "string",
+            "length": 6,
+            "data": "abababababababababababababababababababababababababababababababab"
+          }
+        }
+      ]
+    },
+    "indices": {
+      "width": 3,
+      "data_type": "uint64",
+      "length": 48,
+      "data": "abababababababababababababababababababababababababababababababab",
+      "attributes": [
+        {
+          "name": "chemicals",
+          "key": "chemicals",
+          "attribute_type": "ensemble_category",
+          "nan_description": {
+            "values": [
+              -99,
+              -999
+            ]
+          },
+          "attribute_description": {
+            "discipline": "Geochemistry",
+            "type": "Classification"
+          },
+          "values": {
+            "data_type": "int32",
+            "width": 5,
+            "length": 48,
+            "data": "abababababababababababababababababababababababababababababababab"
+          },
+          "table": {
+            "keys_data_type": "int32",
+            "values_data_type": "string",
+            "length": 12,
+            "data": "abababababababababababababababababababababababababababababababab"
+          }
+        }
+      ]
+    }
+  },
+  "parts": {
+    "chunks": {
+      "width": 2,
+      "data_type": "uint64",
+      "length": 3,
+      "data": "abababababababababababababababababababababababababababababababab"
+    },
+    "triangle_indices": {
+      "width": 1,
+      "data_type": "uint64",
+      "length": 64,
+      "data": "abababababababababababababababababababababababababababababababab"
+    },
+    "attributes": [
+      {
+        "name": "Source",
+        "key": "source",
+        "attribute_type": "string",
+        "values": {
+          "data_type": "string",
+          "length": 3,
+          "data": "abababababababababababababababababababababababababababababababab"
+        }
+      }
+    ]
+  },
+  "edges": {
+    "indices": {
+      "width": 2,
+      "data_type": "uint64",
+      "length": 90,
+      "data": "abababababababababababababababababababababababababababababababab"
+    },
+    "parts": {
+      "chunks": {
+        "width": 2,
+        "data_type": "uint64",
+        "length": 6,
+        "data": "abababababababababababababababababababababababababababababababab"
+      },
+      "attributes": [
+        {
+          "name": "Source",
+          "key": "source",
+          "attribute_type": "string",
+          "values": {
+            "data_type": "string",
+            "length": 6,
+            "data": "abababababababababababababababababababababababababababababababab"
+          }
+        }
+      ]
+    },
+    "attributes": [
+      {
+        "name": "Length",
+        "key": "length",
+        "attribute_type": "scalar",
+        "nan_description": {
+          "values": []
+        },
+        "values": {
+          "data_type": "float64",
+          "width": 1,
+          "length": 90,
+          "data": "abababababababababababababababababababababababababababababababab"
+        }
+      }
+    ]
+  },
+  "quality": {
+    "characteristics": [
+      "Manifold",
+      "NonDegenerate"
+    ]
+  },
+  "tags": {},
+  "extensions": {}
+}

--- a/schema/objects/triangle-mesh/2.3.0/triangle-mesh.schema.json
+++ b/schema/objects/triangle-mesh/2.3.0/triangle-mesh.schema.json
@@ -1,0 +1,79 @@
+{
+  "$id": "/objects/triangle-mesh/2.3.0/triangle-mesh.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "A mesh composed of triangles.\nThe triangles are defined by triplets of indices into a vertex list.\nOptionally, parts and edges can be defined.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "/components/base-spatial-data-properties/1.1.0/base-spatial-data-properties.schema.json"
+    },
+    {
+      "$ref": "/components/embedded-triangulated-mesh/2.1.0/embedded-triangulated-mesh.schema.json"
+    },
+    {
+      "properties": {
+        "schema": {
+          "const": "/objects/triangle-mesh/2.3.0/triangle-mesh.schema.json"
+        },
+        "edges": {
+          "description": "An optional structure defining edges and edge chunks of the mesh.",
+          "$ref": "#/$defs/edges"
+        },
+        "quality": {
+          "$ref": "/components/mesh-quality/1.0.1/mesh-quality.schema.json",
+          "description": "Mesh quality."
+        }
+      }
+    }
+  ],
+  "required": [
+    "schema"
+  ],
+  "unevaluatedProperties": false,
+  "$defs": {
+    "edges": {
+      "description": "A structure defining edges and edge chunks of the mesh.",
+      "allOf": [
+        {
+          "$ref": "/components/attribute-list-property/1.2.0/attribute-list-property.schema.json",
+          "description": "Attributes associated with each edge."
+        },
+        {
+          "properties": {
+            "indices": {
+              "description": "Edges defined by tuples of indices into the vertex list. Columns: start, end",
+              "$ref": "/elements/index-array-2/1.0.1/index-array-2.schema.json"
+            },
+            "parts": {
+              "description": "An optional structure defining edge chunks the mesh is composed of.",
+              "$ref": "#/$defs/edge_parts"
+            }
+          },
+          "required": [
+            "indices"
+          ]
+        }
+      ]
+    },
+    "edge_parts": {
+      "description": "A structure defining edge chunks of the mesh.",
+      "allOf": [
+        {
+          "$ref": "/components/attribute-list-property/1.2.0/attribute-list-property.schema.json",
+          "description": "Attributes associated with each edge chunk."
+        },
+        {
+          "properties": {
+            "chunks": {
+              "description": "A tuple defining the first index and the length of a chunk.\nThe chunk refers to a segment of the edges array.\nChunks do not have to include all edges, and chunks can overlap.\nColumns: offset, count",
+              "$ref": "/elements/index-array-2/1.0.1/index-array-2.schema.json"
+            }
+          },
+          "required": [
+            "chunks"
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Adds a property containing a mesh-quality object to the triangle mesh schema.

<!--
Thank you for taking the time to make a pull request.

Please review our [contribution guide](https://github.com/seequentevo/evo-schemas/blob/main/CONTRIBUTING.md) and our
[code of conduct](https://github.com/seequentevo/evo-schemas/blob/main/CONTRIBUTING.md) before opening your first
pull request.

By making a pull request, you confirm you agree to our Contributor License Agreement (CLA).
-->

## Description

The quality characteristics of a triangle mesh were previously transitively-included in the schema through the embedded-triangulated-mesh schema. During the development of geological-model-meshes v2, the quality property was removed from this schema and moved up to a more specific schema. In triangle-mesh v2, this had the unintended consequence of removing this property altogether, giving no way of describing the quality characteristics of a triangle mesh. This PR restores the property.

## Checklist

- [/] I have read the contributing guide and the code of conduct
