### PR TITLE
Create new triangle-mesh minor version with optional quality property

### DIFF
--- a/docs/schemas/components/mesh-quality.md
+++ b/docs/schemas/components/mesh-quality.md
@@ -19,7 +19,7 @@ The quality can be one or more of:
 - "NonSelfIntersecting": No element in a mesh intersects another.
 - "Continuous": Adjacent elements share nodes.
 
-**Used by:** [embedded-mesh-object](embedded-mesh-object.md), [embedded-triangulated-mesh](embedded-triangulated-mesh.md), [surface-mesh](surface-mesh.md).
+**Used by:** [embedded-mesh-object](embedded-mesh-object.md), [embedded-triangulated-mesh](embedded-triangulated-mesh.md), [surface-mesh](surface-mesh.md), [triangle-mesh](../objects/triangle-mesh.md).
 
 ## Properties
 

--- a/docs/schemas/generated/flatmd/objects/triangle-mesh-2.3.0-edges-edge_parts.md
+++ b/docs/schemas/generated/flatmd/objects/triangle-mesh-2.3.0-edges-edge_parts.md
@@ -1,0 +1,19 @@
+### triangle-mesh (v2.3.0)
+A structure defining edge chunks of the mesh.
+
+| Property | Type | Description | Flags |
+|---|---|---|---|
+| attributes | [one-of-attribute](../components/one-of-attribute-1.2.0.md) | Attribute data. | [⬆️](../components/attribute-list-property-1.2.0.md) |
+| chunks | [index-array-2](../elements/index-array-2-1.0.1.md) | A tuple defining the first index and the length of a chunk.
+The chunk refers to a segment of the edges array.
+Chunks do not have to include all edges, and chunks can overlap.
+Columns: offset, count | ✅ |
+
+
+#### Legend
+
+| Flag | Description |
+| --- | --- |
+| ⬆️ | Inherited property |
+| ✅ | Required property |
+

--- a/docs/schemas/generated/flatmd/objects/triangle-mesh-2.3.0-edges.md
+++ b/docs/schemas/generated/flatmd/objects/triangle-mesh-2.3.0-edges.md
@@ -1,0 +1,17 @@
+### triangle-mesh (v2.3.0)
+A structure defining edges and edge chunks of the mesh.
+
+| Property | Type | Description | Flags |
+|---|---|---|---|
+| attributes | [one-of-attribute](../components/one-of-attribute-1.2.0.md) | Attribute data. | [⬆️](../components/attribute-list-property-1.2.0.md) |
+| indices | [index-array-2](../elements/index-array-2-1.0.1.md) | Edges defined by tuples of indices into the vertex list. Columns: start, end | ✅ |
+| parts | [triangle-mesh](../objects/triangle-mesh-2.3.0-edges-edge_parts.md) | An optional structure defining edge chunks the mesh is composed of. |  |
+
+
+#### Legend
+
+| Flag | Description |
+| --- | --- |
+| ⬆️ | Inherited property |
+| ✅ | Required property |
+

--- a/docs/schemas/generated/flatmd/objects/triangle-mesh-2.3.0.md
+++ b/docs/schemas/generated/flatmd/objects/triangle-mesh-2.3.0.md
@@ -1,0 +1,29 @@
+### triangle-mesh (v2.3.0)
+A mesh composed of triangles.
+The triangles are defined by triplets of indices into a vertex list.
+Optionally, parts and edges can be defined.
+
+| Property | Type | Description | Flags |
+|---|---|---|---|
+| name | String | Name of the object. | [⬆️](../components/base-object-properties-1.1.0.md) ✅ |
+| uuid | [base-object-properties](../components/base-object-properties-1.1.0-uuid.md) | Identifier of the object. | [⬆️](../components/base-object-properties-1.1.0.md) ✅ |
+| description | String | Optional field for adding additional description to uniquely identify this object. | [⬆️](../components/base-object-properties-1.1.0.md) |
+| extensions | Object | Extended properties that may be associated to the object, but not specified in the schema | [⬆️](../components/base-object-properties-1.1.0.md) |
+| tags | Object | Key-value pairs of user-defined metadata | [⬆️](../components/base-object-properties-1.1.0.md) |
+| lineage | [lineage](../components/lineage-1.0.0.md) | Information about the history of the object | [⬆️](../components/base-object-properties-1.1.0.md) |
+| bounding_box | [bounding-box](../components/bounding-box-1.0.1.md) | Bounding box of the spatial data. | [⬆️](../components/base-spatial-data-properties-1.1.0.md) ✅ |
+| coordinate_reference_system | [crs](../components/crs-1.0.1.md) | Coordinate system of the spatial data | [⬆️](../components/base-spatial-data-properties-1.1.0.md) ✅ |
+| triangles | [triangles](../components/triangles-1.2.0.md) | The vertices and triangle indices of the mesh. | [⬆️](../components/embedded-triangulated-mesh-2.1.0.md) ✅ |
+| parts | [embedded-triangulated-mesh](../components/embedded-triangulated-mesh-2.1.0-parts.md) | A structure defining triangle chunks the mesh is composed of. | [⬆️](../components/embedded-triangulated-mesh-2.1.0.md) |
+| schema | String |  | ✅ |
+| edges | [triangle-mesh](../objects/triangle-mesh-2.3.0-edges.md) | An optional structure defining edges and edge chunks of the mesh. |  |
+| quality | [mesh-quality](../components/mesh-quality-1.0.1.md) | Mesh quality. |  |
+
+
+#### Legend
+
+| Flag | Description |
+| --- | --- |
+| ⬆️ | Inherited property |
+| ✅ | Required property |
+

--- a/docs/schemas/generated/uml/triangle-mesh-2.3.0.mmd
+++ b/docs/schemas/generated/uml/triangle-mesh-2.3.0.mmd
@@ -1,0 +1,165 @@
+---
+config:
+    class:
+        hideEmptyMembersBox: true
+---
+
+classDiagram
+    class `components/base-object-properties-1.1.0`:::schemaComponent {
+        name: string
+        uuid: components/base-object-properties-1.1.0-uuid
+        description: string
+        extensions: object
+        tags: object
+        lineage: components/lineage-1.0.0
+    }
+    class `components/base-spatial-data-properties-1.1.0`:::schemaComponent {
+        name: string*
+        uuid: components/base-object-properties-1.1.0-uuid*
+        description: string*
+        extensions: object*
+        tags: object*
+        lineage: components/lineage-1.0.0*
+        bounding_box: components/bounding-box-1.0.1
+        coordinate_reference_system: components/crs-1.0.1
+    }
+    `components/base-object-properties-1.1.0` <|-- `components/base-spatial-data-properties-1.1.0`
+    class `components/embedded-triangulated-mesh-2.1.0`:::schemaComponent {
+        triangles: components/triangles-1.2.0
+        parts: components/embedded-triangulated-mesh-2.1.0-parts
+    }
+    class `objects/triangle-mesh-2.3.0`:::schemaObject {
+        name: string*
+        uuid: components/base-object-properties-1.1.0-uuid*
+        description: string*
+        extensions: object*
+        tags: object*
+        lineage: components/lineage-1.0.0*
+        bounding_box: components/bounding-box-1.0.1*
+        coordinate_reference_system: components/crs-1.0.1*
+        triangles: components/triangles-1.2.0*
+        parts: components/embedded-triangulated-mesh-2.1.0-parts*
+        edges: objects/triangle-mesh-2.3.0-edges
+        quality: components/mesh-quality-1.0.1
+    }
+    `components/base-object-properties-1.1.0` <|-- `objects/triangle-mesh-2.3.0`
+    `components/base-spatial-data-properties-1.1.0` <|-- `objects/triangle-mesh-2.3.0`
+    `components/embedded-triangulated-mesh-2.1.0` <|-- `objects/triangle-mesh-2.3.0`
+    `components/base-object-properties-1.1.0` *-- `components/base-object-properties-1.1.0-uuid` : ref uuid*
+    `components/base-object-properties-1.1.0` *-- `components/lineage-1.0.0` : ref lineage*
+    `components/base-spatial-data-properties-1.1.0` *-- `components/bounding-box-1.0.1` : ref bounding_box*
+    `components/base-spatial-data-properties-1.1.0` *-- `components/crs-1.0.1` : ref coordinate_reference_system*
+    `components/embedded-triangulated-mesh-2.1.0` *-- `components/triangles-1.2.0` : ref triangles*
+    `components/embedded-triangulated-mesh-2.1.0` *-- `components/embedded-triangulated-mesh-2.1.0-parts` : ref parts*
+    `objects/triangle-mesh-2.3.0` *-- `objects/triangle-mesh-2.3.0-edges` : ref edges*
+    `objects/triangle-mesh-2.3.0` *-- `components/mesh-quality-1.0.1` : ref quality*
+    class `components/base-object-properties-1.1.0-uuid`:::schemaImplicit {
+    }
+    class `components/lineage-1.0.0`:::schemaComponent {
+        self_link: string
+        events: array
+    }
+    class `components/bounding-box-1.0.1`:::schemaComponent {
+        min_x: number
+        max_x: number
+        min_y: number
+        max_y: number
+        min_z: number
+        max_z: number
+    }
+    class `components/crs-1.0.1`:::schemaComponent {
+    }
+    class `components/triangles-1.2.0`:::schemaComponent {
+        vertices: components/triangles-1.2.0-vertices
+        indices: components/triangles-1.2.0-indices
+    }
+    `components/triangles-1.2.0` *-- `components/triangles-1.2.0-vertices` : ref vertices*
+    `components/triangles-1.2.0` *-- `components/triangles-1.2.0-indices` : ref indices*
+    class `elements/float-array-md-1.0.1`:::schemaElement {
+        data: elements/binary-blob-1.0.1
+        length: integer
+        width: integer
+        data_type: string = float64
+    }
+    class `elements/float-array-3-1.0.1`:::schemaElement {
+        data: elements/binary-blob-1.0.1*
+        length: integer*
+        data_type: string = float64*
+        width: integer = 3
+    }
+    `elements/float-array-md-1.0.1` <|-- `elements/float-array-3-1.0.1`
+    class `components/attribute-list-property-1.2.0`:::schemaComponent {
+        attributes: components/one-of-attribute-1.2.0
+    }
+    class `components/triangles-1.2.0-vertices`:::schemaImplicit {
+        data: elements/binary-blob-1.0.1*
+        length: integer*
+        width: integer*
+        data_type: string = float64*
+        width: integer = 3*
+        attributes: components/one-of-attribute-1.2.0*
+    }
+    `elements/float-array-md-1.0.1` <|-- `components/triangles-1.2.0-vertices`
+    `elements/float-array-3-1.0.1` <|-- `components/triangles-1.2.0-vertices`
+    `components/attribute-list-property-1.2.0` <|-- `components/triangles-1.2.0-vertices`
+    `elements/float-array-md-1.0.1` *-- `elements/binary-blob-1.0.1` : ref data*
+    `components/attribute-list-property-1.2.0` *-- `components/one-of-attribute-1.2.0` : ref attributes*
+    class `elements/binary-blob-1.0.1`:::schemaElement {
+    }
+    class `components/one-of-attribute-1.2.0`:::schemaComponent {
+    }
+    class `elements/index-array-3-1.0.1`:::schemaElement {
+        data: elements/binary-blob-1.0.1
+        length: integer
+        width: integer = 3
+        data_type: string = uint64
+    }
+    class `components/triangles-1.2.0-indices`:::schemaImplicit {
+        data: elements/binary-blob-1.0.1*
+        length: integer*
+        width: integer = 3*
+        data_type: string = uint64*
+        attributes: components/one-of-attribute-1.2.0*
+    }
+    `elements/index-array-3-1.0.1` <|-- `components/triangles-1.2.0-indices`
+    `components/attribute-list-property-1.2.0` <|-- `components/triangles-1.2.0-indices`
+    `elements/index-array-3-1.0.1` *-- `elements/binary-blob-1.0.1` : ref data*
+    class `components/embedded-triangulated-mesh-2.1.0-parts`:::schemaImplicit {
+        attributes: components/one-of-attribute-1.2.0*
+        chunks: elements/index-array-2-1.0.1
+        triangle_indices: elements/index-array-1-1.0.1
+    }
+    `components/attribute-list-property-1.2.0` <|-- `components/embedded-triangulated-mesh-2.1.0-parts`
+    `components/embedded-triangulated-mesh-2.1.0-parts` *-- `elements/index-array-2-1.0.1` : ref chunks*
+    `components/embedded-triangulated-mesh-2.1.0-parts` *-- `elements/index-array-1-1.0.1` : ref triangle_indices*
+    class `elements/index-array-2-1.0.1`:::schemaElement {
+        data: elements/binary-blob-1.0.1
+        length: integer
+        width: integer = 2
+        data_type: string = uint64
+    }
+    `elements/index-array-2-1.0.1` *-- `elements/binary-blob-1.0.1` : ref data*
+    class `elements/index-array-1-1.0.1`:::schemaElement {
+        data: elements/binary-blob-1.0.1
+        length: integer
+        width: integer = 1
+        data_type: string = uint64
+    }
+    `elements/index-array-1-1.0.1` *-- `elements/binary-blob-1.0.1` : ref data*
+    class `objects/triangle-mesh-2.3.0-edges`:::schemaImplicit {
+        attributes: components/one-of-attribute-1.2.0*
+        indices: elements/index-array-2-1.0.1
+        parts: objects/triangle-mesh-2.3.0-edges-edge_parts
+    }
+    `components/attribute-list-property-1.2.0` <|-- `objects/triangle-mesh-2.3.0-edges`
+    `objects/triangle-mesh-2.3.0-edges` *-- `elements/index-array-2-1.0.1` : ref indices*
+    `objects/triangle-mesh-2.3.0-edges` *-- `objects/triangle-mesh-2.3.0-edges-edge_parts` : ref parts*
+    class `objects/triangle-mesh-2.3.0-edges-edge_parts`:::schemaImplicit {
+        attributes: components/one-of-attribute-1.2.0*
+        chunks: elements/index-array-2-1.0.1
+    }
+    `components/attribute-list-property-1.2.0` <|-- `objects/triangle-mesh-2.3.0-edges-edge_parts`
+    `objects/triangle-mesh-2.3.0-edges-edge_parts` *-- `elements/index-array-2-1.0.1` : ref chunks*
+    class `components/mesh-quality-1.0.1`:::schemaComponent {
+        characteristics: array
+    }

--- a/docs/schemas/objects/triangle-mesh.md
+++ b/docs/schemas/objects/triangle-mesh.md
@@ -1,14 +1,15 @@
 import OverlineWithVersion from '@theme/OverlineWithVersion';
 import SchemaUri from '@theme/SchemaUri';
-import FlatProperties from '../generated/flatmd/objects/triangle-mesh-2.2.0.md';
+import FlatProperties from '../generated/flatmd/objects/triangle-mesh-2.3.0.md';
 
-<OverlineWithVersion title="Geoscience Objects" version="2.2.0" badge="supported" />
+<OverlineWithVersion title="Geoscience Objects" version="2.3.0" badge="supported" />
 
 # triangle-mesh
 
-<SchemaUri uri="schema/objects/triangle-mesh/2.2.0/triangle-mesh.schema.json" />
+<SchemaUri uri="schema/objects/triangle-mesh/2.3.0/triangle-mesh.schema.json" />
 
 **Key components:**
+- [mesh-quality](../components/mesh-quality.md) — Mesh quality guarantees
 - [segments](../components/segments.md) — Line segments defined by vertex index pairs
 
 **See also:** [line-segments](line-segments.md) (line geometry), [pointset](pointset.md) (vertices only).
@@ -40,6 +41,9 @@ Each chunk is a tuple defining the first index and the length of a chunk of vert
 `triangle_indices`
 An optional index array into the triangle indices set. This is used to define chunks if the mesh triangle indices do not contain contiguous chunks.
 
+### quality
+Optional hint about mesh [quality](../components/mesh-quality.md) characteristics that provide guarantees about the mesh (e.g., manifold, consistent winding, non-degenerate).
+
 ### edges
 An optional structure defining edges and edge chunks of the mesh. An optional attribute can be associated with each edge.
 
@@ -55,4 +59,4 @@ An optional structure defining edges and edge chunks of the mesh. An optional at
 
 <FlatProperties />
 
-::mermaid[../generated/uml/triangle-mesh-2.2.0.mmd]
+::mermaid[../generated/uml/triangle-mesh-2.3.0.mmd]

--- a/examples/2.3.0/objects/triangle-mesh-1.json
+++ b/examples/2.3.0/objects/triangle-mesh-1.json
@@ -1,0 +1,166 @@
+{
+  "schema": "/objects/triangle-mesh/2.3.0/triangle-mesh.schema.json",
+  "name": "Example Triangle Mesh",
+  "uuid": "00000000-0000-0000-0000-000000000000",
+  "description": "This is example data to ensure triangle mesh validates properly",
+  "bounding_box": {
+    "min_y": 5,
+    "max_y": 10,
+    "min_x": 0,
+    "max_x": 10,
+    "min_z": 5,
+    "max_z": 10
+  },
+  "coordinate_reference_system": {
+    "epsg_code": 1024
+  },
+  "triangles": {
+    "vertices": {
+      "width": 3,
+      "data_type": "float64",
+      "length": 64,
+      "data": "abababababababababababababababababababababababababababababababab",
+      "attributes": [
+        {
+          "name": "lithology",
+          "key": "lith",
+          "attribute_type": "category",
+          "nan_description": {
+            "values": [
+              -99
+            ]
+          },
+          "attribute_description": {
+            "discipline": "Geology",
+            "type": "Rock Type"
+          },
+          "values": {
+            "data_type": "int32",
+            "length": 64,
+            "width": 1,
+            "data": "abababababababababababababababababababababababababababababababab"
+          },
+          "table": {
+            "keys_data_type": "int32",
+            "values_data_type": "string",
+            "length": 6,
+            "data": "abababababababababababababababababababababababababababababababab"
+          }
+        }
+      ]
+    },
+    "indices": {
+      "width": 3,
+      "data_type": "uint64",
+      "length": 48,
+      "data": "abababababababababababababababababababababababababababababababab",
+      "attributes": [
+        {
+          "name": "chemicals",
+          "key": "chemicals",
+          "attribute_type": "ensemble_category",
+          "nan_description": {
+            "values": [
+              -99,
+              -999
+            ]
+          },
+          "attribute_description": {
+            "discipline": "Geochemistry",
+            "type": "Classification"
+          },
+          "values": {
+            "data_type": "int32",
+            "width": 5,
+            "length": 48,
+            "data": "abababababababababababababababababababababababababababababababab"
+          },
+          "table": {
+            "keys_data_type": "int32",
+            "values_data_type": "string",
+            "length": 12,
+            "data": "abababababababababababababababababababababababababababababababab"
+          }
+        }
+      ]
+    }
+  },
+  "parts": {
+    "chunks": {
+      "width": 2,
+      "data_type": "uint64",
+      "length": 3,
+      "data": "abababababababababababababababababababababababababababababababab"
+    },
+    "triangle_indices": {
+      "width": 1,
+      "data_type": "uint64",
+      "length": 64,
+      "data": "abababababababababababababababababababababababababababababababab"
+    },
+    "attributes": [
+      {
+        "name": "Source",
+        "key": "source",
+        "attribute_type": "string",
+        "values": {
+          "data_type": "string",
+          "length": 3,
+          "data": "abababababababababababababababababababababababababababababababab"
+        }
+      }
+    ]
+  },
+  "edges": {
+    "indices": {
+      "width": 2,
+      "data_type": "uint64",
+      "length": 90,
+      "data": "abababababababababababababababababababababababababababababababab"
+    },
+    "parts": {
+      "chunks": {
+        "width": 2,
+        "data_type": "uint64",
+        "length": 6,
+        "data": "abababababababababababababababababababababababababababababababab"
+      },
+      "attributes": [
+        {
+          "name": "Source",
+          "key": "source",
+          "attribute_type": "string",
+          "values": {
+            "data_type": "string",
+            "length": 6,
+            "data": "abababababababababababababababababababababababababababababababab"
+          }
+        }
+      ]
+    },
+    "attributes": [
+      {
+        "name": "Length",
+        "key": "length",
+        "attribute_type": "scalar",
+        "nan_description": {
+          "values": []
+        },
+        "values": {
+          "data_type": "float64",
+          "width": 1,
+          "length": 90,
+          "data": "abababababababababababababababababababababababababababababababab"
+        }
+      }
+    ]
+  },
+  "quality": {
+    "characteristics": [
+      "Manifold",
+      "NonDegenerate"
+    ]
+  },
+  "tags": {},
+  "extensions": {}
+}

--- a/schema/geoscience-objects.schema.json
+++ b/schema/geoscience-objects.schema.json
@@ -293,6 +293,9 @@
       "$ref": "/objects/triangle-mesh/2.2.0/triangle-mesh.schema.json"
     },
     {
+      "$ref": "/objects/triangle-mesh/2.3.0/triangle-mesh.schema.json"
+    },
+    {
       "$ref": "/objects/unstructured-grid/1.0.1/unstructured-grid.schema.json"
     },
     {

--- a/schema/objects/triangle-mesh/2.3.0/triangle-mesh.schema.json
+++ b/schema/objects/triangle-mesh/2.3.0/triangle-mesh.schema.json
@@ -1,0 +1,79 @@
+{
+  "$id": "/objects/triangle-mesh/2.3.0/triangle-mesh.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "A mesh composed of triangles.\nThe triangles are defined by triplets of indices into a vertex list.\nOptionally, parts and edges can be defined.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "/components/base-spatial-data-properties/1.1.0/base-spatial-data-properties.schema.json"
+    },
+    {
+      "$ref": "/components/embedded-triangulated-mesh/2.1.0/embedded-triangulated-mesh.schema.json"
+    },
+    {
+      "properties": {
+        "schema": {
+          "const": "/objects/triangle-mesh/2.3.0/triangle-mesh.schema.json"
+        },
+        "edges": {
+          "description": "An optional structure defining edges and edge chunks of the mesh.",
+          "$ref": "#/$defs/edges"
+        },
+        "quality": {
+          "$ref": "/components/mesh-quality/1.0.1/mesh-quality.schema.json",
+          "description": "Mesh quality."
+        }
+      }
+    }
+  ],
+  "required": [
+    "schema"
+  ],
+  "unevaluatedProperties": false,
+  "$defs": {
+    "edges": {
+      "description": "A structure defining edges and edge chunks of the mesh.",
+      "allOf": [
+        {
+          "$ref": "/components/attribute-list-property/1.2.0/attribute-list-property.schema.json",
+          "description": "Attributes associated with each edge."
+        },
+        {
+          "properties": {
+            "indices": {
+              "description": "Edges defined by tuples of indices into the vertex list. Columns: start, end",
+              "$ref": "/elements/index-array-2/1.0.1/index-array-2.schema.json"
+            },
+            "parts": {
+              "description": "An optional structure defining edge chunks the mesh is composed of.",
+              "$ref": "#/$defs/edge_parts"
+            }
+          },
+          "required": [
+            "indices"
+          ]
+        }
+      ]
+    },
+    "edge_parts": {
+      "description": "A structure defining edge chunks of the mesh.",
+      "allOf": [
+        {
+          "$ref": "/components/attribute-list-property/1.2.0/attribute-list-property.schema.json",
+          "description": "Attributes associated with each edge chunk."
+        },
+        {
+          "properties": {
+            "chunks": {
+              "description": "A tuple defining the first index and the length of a chunk.\nThe chunk refers to a segment of the edges array.\nChunks do not have to include all edges, and chunks can overlap.\nColumns: offset, count",
+              "$ref": "/elements/index-array-2/1.0.1/index-array-2.schema.json"
+            }
+          },
+          "required": [
+            "chunks"
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Description

This incorporates @ArthurGW's changes on https://github.com/SeequentEvo/evo-schemas/pull/62 and adds necessary documentation / cross-linking. @ArthurGW is out of office and so I'm pulling this request out to a separate PR to allow us to move forward.

@ArthurGW wrote:
> Adds a property containing a mesh-quality object to the triangle mesh schema.

> The quality characteristics of a triangle mesh were previously transitively-included in the schema through the embedded-triangulated-mesh schema. During the development of geological-model-meshes v2, the quality property was removed from this schema and moved up to a more specific schema. In triangle-mesh v2, this had the unintended consequence of removing this property altogether, giving no way of describing the quality characteristics of a triangle mesh. This PR restores the property.

> I haven't yet added any new docs for this, not sure if there is anything I need to do? I guess this new property would appear in the generated docs, but do I have to manually generate them?

## Checklist

- [x] I have read the contributing guide and the code of conduct

Closes #62 