### PR TITLE
Use tag friendly br tags

### DIFF
--- a/docs/schemas/generated/flatmd/components/base-attribute-1.0.0.md
+++ b/docs/schemas/generated/flatmd/components/base-attribute-1.0.0.md
@@ -4,7 +4,7 @@ A base schema for attributes.
 | Property | Type | Description | Flags |
 |---|---|---|---|
 | name | String | The name of the attribute | ✅ |
-| key | String | An identifier of the attribute, used to keep track of the attribute when it is renamed.<br>The identifier must be unique within an attribute list. | ✅ |
+| key | String | An identifier of the attribute, used to keep track of the attribute when it is renamed.<br/>The identifier must be unique within an attribute list. | ✅ |
 | attribute_type | String | Type of the attribute. | ✅ |
 
 

--- a/docs/schemas/generated/flatmd/components/base-category-attribute-1.0.0.md
+++ b/docs/schemas/generated/flatmd/components/base-category-attribute-1.0.0.md
@@ -4,7 +4,7 @@ A base schema for categorial attributes.
 | Property | Type | Description | Flags |
 |---|---|---|---|
 | name | String | The name of the attribute | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
-| key | String | An identifier of the attribute, used to keep track of the attribute when it is renamed.<br>The identifier must be unique within an attribute list. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
+| key | String | An identifier of the attribute, used to keep track of the attribute when it is renamed.<br/>The identifier must be unique within an attribute list. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
 | attribute_type | String | Type of the attribute. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
 | attribute_description | [category-attribute-description](../components/category-attribute-description-1.0.1.md) | The attribute description record. |  |
 

--- a/docs/schemas/generated/flatmd/components/base-continuous-attribute-1.0.0.md
+++ b/docs/schemas/generated/flatmd/components/base-continuous-attribute-1.0.0.md
@@ -4,7 +4,7 @@ A base schema for continuous attributes.
 | Property | Type | Description | Flags |
 |---|---|---|---|
 | name | String | The name of the attribute | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
-| key | String | An identifier of the attribute, used to keep track of the attribute when it is renamed.<br>The identifier must be unique within an attribute list. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
+| key | String | An identifier of the attribute, used to keep track of the attribute when it is renamed.<br/>The identifier must be unique within an attribute list. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
 | attribute_type | String | Type of the attribute. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
 | attribute_description | [attribute-description](../components/attribute-description-1.0.1.md) | The attribute description record. |  |
 

--- a/docs/schemas/generated/flatmd/components/block-model-attribute-1.0.0.md
+++ b/docs/schemas/generated/flatmd/components/block-model-attribute-1.0.0.md
@@ -4,7 +4,7 @@ A block model attribute.
 | Property | Type | Description | Flags |
 |---|---|---|---|
 | name | String | The name of the attribute | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
-| key | String | An identifier of the attribute, used to keep track of the attribute when it is renamed.<br>The identifier must be unique within an attribute list. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
+| key | String | An identifier of the attribute, used to keep track of the attribute when it is renamed.<br/>The identifier must be unique within an attribute list. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
 | attribute_type | String | Type of the attribute. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
 | attribute_description | [attribute-description](../components/attribute-description-1.0.1.md) | The attribute description record. | [⬆️](../components/base-continuous-attribute-1.0.0.md) |
 | attribute_type | String | The data type of the attribute as stored in the Block Model Service. | ✅ |

--- a/docs/schemas/generated/flatmd/components/block-model-category-attribute-1.0.0.md
+++ b/docs/schemas/generated/flatmd/components/block-model-category-attribute-1.0.0.md
@@ -4,7 +4,7 @@ A block model category/string attribute stored by the Block Model Service.
 | Property | Type | Description | Flags |
 |---|---|---|---|
 | name | String | The name of the attribute | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
-| key | String | An identifier of the attribute, used to keep track of the attribute when it is renamed.<br>The identifier must be unique within an attribute list. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
+| key | String | An identifier of the attribute, used to keep track of the attribute when it is renamed.<br/>The identifier must be unique within an attribute list. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
 | attribute_type | String | Type of the attribute. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
 | attribute_description | [category-attribute-description](../components/category-attribute-description-1.0.1.md) | The attribute description record. | [⬆️](../components/base-category-attribute-1.0.0.md) |
 | attribute_type | String | The data type of the attribute as stored in the Block Model Service. | ✅ |

--- a/docs/schemas/generated/flatmd/components/bool-attribute-1.1.0.md
+++ b/docs/schemas/generated/flatmd/components/bool-attribute-1.1.0.md
@@ -4,7 +4,7 @@ An attribute for boolean values.
 | Property | Type | Description | Flags |
 |---|---|---|---|
 | name | String | The name of the attribute | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
-| key | String | An identifier of the attribute, used to keep track of the attribute when it is renamed.<br>The identifier must be unique within an attribute list. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
+| key | String | An identifier of the attribute, used to keep track of the attribute when it is renamed.<br/>The identifier must be unique within an attribute list. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
 | attribute_type | String | Type of the attribute. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
 | attribute_description | [category-attribute-description](../components/category-attribute-description-1.0.1.md) | The attribute description record. | [⬆️](../components/base-category-attribute-1.0.0.md) |
 | attribute_type | String |  | ✅ |

--- a/docs/schemas/generated/flatmd/components/bool-time-series-1.1.0.md
+++ b/docs/schemas/generated/flatmd/components/bool-time-series-1.1.0.md
@@ -4,7 +4,7 @@ An attribute that describes a bool time series.
 | Property | Type | Description | Flags |
 |---|---|---|---|
 | name | String | The name of the attribute | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
-| key | String | An identifier of the attribute, used to keep track of the attribute when it is renamed.<br>The identifier must be unique within an attribute list. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
+| key | String | An identifier of the attribute, used to keep track of the attribute when it is renamed.<br/>The identifier must be unique within an attribute list. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
 | attribute_type | String | Type of the attribute. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
 | attribute_description | [attribute-description](../components/attribute-description-1.0.1.md) | The attribute description record. | [⬆️](../components/base-continuous-attribute-1.0.0.md) |
 | attribute_type | String |  | ✅ |

--- a/docs/schemas/generated/flatmd/components/category-attribute-1.1.0.md
+++ b/docs/schemas/generated/flatmd/components/category-attribute-1.1.0.md
@@ -4,7 +4,7 @@ An attribute that describes a category.
 | Property | Type | Description | Flags |
 |---|---|---|---|
 | name | String | The name of the attribute | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
-| key | String | An identifier of the attribute, used to keep track of the attribute when it is renamed.<br>The identifier must be unique within an attribute list. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
+| key | String | An identifier of the attribute, used to keep track of the attribute when it is renamed.<br/>The identifier must be unique within an attribute list. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
 | attribute_type | String | Type of the attribute. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
 | attribute_description | [category-attribute-description](../components/category-attribute-description-1.0.1.md) | The attribute description record. | [⬆️](../components/base-category-attribute-1.0.0.md) |
 | table | [lookup-table](../elements/lookup-table-1.0.1.md) | Lookup table associated with the attributes. | [⬆️](../components/category-data-1.0.1.md) ✅ |

--- a/docs/schemas/generated/flatmd/components/category-ensemble-1.1.0.md
+++ b/docs/schemas/generated/flatmd/components/category-ensemble-1.1.0.md
@@ -4,7 +4,7 @@ Category ensemble.
 | Property | Type | Description | Flags |
 |---|---|---|---|
 | name | String | The name of the attribute | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
-| key | String | An identifier of the attribute, used to keep track of the attribute when it is renamed.<br>The identifier must be unique within an attribute list. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
+| key | String | An identifier of the attribute, used to keep track of the attribute when it is renamed.<br/>The identifier must be unique within an attribute list. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
 | attribute_type | String | Type of the attribute. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
 | attribute_description | [category-attribute-description](../components/category-attribute-description-1.0.1.md) | The attribute description record. | [⬆️](../components/base-category-attribute-1.0.0.md) |
 | attribute_type | String |  | ✅ |

--- a/docs/schemas/generated/flatmd/components/category-time-series-1.1.0.md
+++ b/docs/schemas/generated/flatmd/components/category-time-series-1.1.0.md
@@ -4,7 +4,7 @@ An attribute that describes a category time series.
 | Property | Type | Description | Flags |
 |---|---|---|---|
 | name | String | The name of the attribute | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
-| key | String | An identifier of the attribute, used to keep track of the attribute when it is renamed.<br>The identifier must be unique within an attribute list. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
+| key | String | An identifier of the attribute, used to keep track of the attribute when it is renamed.<br/>The identifier must be unique within an attribute list. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
 | attribute_type | String | Type of the attribute. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
 | attribute_description | [category-attribute-description](../components/category-attribute-description-1.0.1.md) | The attribute description record. | [⬆️](../components/base-category-attribute-1.0.0.md) |
 | attribute_type | String |  | ✅ |

--- a/docs/schemas/generated/flatmd/components/color-attribute-1.1.0.md
+++ b/docs/schemas/generated/flatmd/components/color-attribute-1.1.0.md
@@ -4,7 +4,7 @@ An attribute for color values.
 | Property | Type | Description | Flags |
 |---|---|---|---|
 | name | String | The name of the attribute | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
-| key | String | An identifier of the attribute, used to keep track of the attribute when it is renamed.<br>The identifier must be unique within an attribute list. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
+| key | String | An identifier of the attribute, used to keep track of the attribute when it is renamed.<br/>The identifier must be unique within an attribute list. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
 | attribute_type | String | Type of the attribute. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
 | attribute_description | [attribute-description](../components/attribute-description-1.0.1.md) | The attribute description record. | [⬆️](../components/base-continuous-attribute-1.0.0.md) |
 | attribute_type | String |  | ✅ |

--- a/docs/schemas/generated/flatmd/components/continuous-attribute-1.1.0.md
+++ b/docs/schemas/generated/flatmd/components/continuous-attribute-1.1.0.md
@@ -4,7 +4,7 @@ An attribute for a range of values.
 | Property | Type | Description | Flags |
 |---|---|---|---|
 | name | String | The name of the attribute | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
-| key | String | An identifier of the attribute, used to keep track of the attribute when it is renamed.<br>The identifier must be unique within an attribute list. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
+| key | String | An identifier of the attribute, used to keep track of the attribute when it is renamed.<br/>The identifier must be unique within an attribute list. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
 | attribute_type | String | Type of the attribute. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
 | attribute_description | [attribute-description](../components/attribute-description-1.0.1.md) | The attribute description record. | [⬆️](../components/base-continuous-attribute-1.0.0.md) |
 | attribute_type | String |  | ✅ |

--- a/docs/schemas/generated/flatmd/components/continuous-ensemble-1.1.0.md
+++ b/docs/schemas/generated/flatmd/components/continuous-ensemble-1.1.0.md
@@ -4,7 +4,7 @@ Continuous ensemble.
 | Property | Type | Description | Flags |
 |---|---|---|---|
 | name | String | The name of the attribute | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
-| key | String | An identifier of the attribute, used to keep track of the attribute when it is renamed.<br>The identifier must be unique within an attribute list. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
+| key | String | An identifier of the attribute, used to keep track of the attribute when it is renamed.<br/>The identifier must be unique within an attribute list. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
 | attribute_type | String | Type of the attribute. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
 | attribute_description | [attribute-description](../components/attribute-description-1.0.1.md) | The attribute description record. | [⬆️](../components/base-continuous-attribute-1.0.0.md) |
 | attribute_type | String |  | ✅ |

--- a/docs/schemas/generated/flatmd/components/continuous-time-series-1.1.0.md
+++ b/docs/schemas/generated/flatmd/components/continuous-time-series-1.1.0.md
@@ -4,7 +4,7 @@ An attribute that describes a continuous time series.
 | Property | Type | Description | Flags |
 |---|---|---|---|
 | name | String | The name of the attribute | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
-| key | String | An identifier of the attribute, used to keep track of the attribute when it is renamed.<br>The identifier must be unique within an attribute list. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
+| key | String | An identifier of the attribute, used to keep track of the attribute when it is renamed.<br/>The identifier must be unique within an attribute list. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
 | attribute_type | String | Type of the attribute. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
 | attribute_description | [attribute-description](../components/attribute-description-1.0.1.md) | The attribute description record. | [⬆️](../components/base-continuous-attribute-1.0.0.md) |
 | attribute_type | String |  | ✅ |

--- a/docs/schemas/generated/flatmd/components/date-time-attribute-1.1.0.md
+++ b/docs/schemas/generated/flatmd/components/date-time-attribute-1.1.0.md
@@ -4,7 +4,7 @@ An attribute for a range of timestamps.
 | Property | Type | Description | Flags |
 |---|---|---|---|
 | name | String | The name of the attribute | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
-| key | String | An identifier of the attribute, used to keep track of the attribute when it is renamed.<br>The identifier must be unique within an attribute list. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
+| key | String | An identifier of the attribute, used to keep track of the attribute when it is renamed.<br/>The identifier must be unique within an attribute list. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
 | attribute_type | String | Type of the attribute. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
 | attribute_description | [attribute-description](../components/attribute-description-1.0.1.md) | The attribute description record. | [⬆️](../components/base-continuous-attribute-1.0.0.md) |
 | attribute_type | String |  | ✅ |

--- a/docs/schemas/generated/flatmd/components/embedded-line-geometry-1.0.0.md
+++ b/docs/schemas/generated/flatmd/components/embedded-line-geometry-1.0.0.md
@@ -4,8 +4,8 @@ A set of polylines composed of straight line segments.
 | Property | Type | Description | Flags |
 |---|---|---|---|
 | vertices | [embedded-line-geometry](../components/embedded-line-geometry-1.0.0-vertices.md) | Vertex coordinates in 2D space. Columns: u, v. | ✅ |
-| chunks | [embedded-line-geometry](../components/embedded-line-geometry-1.0.0-chunks.md) | A tuple defining the first index and the length of a chunk of vertices, forming a polyline/polygon.<br>If indices is defined, the chunk refers to a segment of the indices array.<br>Otherwise, the chunk refers to a segment of the vertices array.<br>Chunks can overlap.<br>Columns: offset, count | ✅ |
-| indices | [index-array-1](../elements/index-array-1-1.0.1.md) | An optional index array into the vertices.<br>This is used to define chunks if the vertices list do not contain contiguous chunks. |  |
+| chunks | [embedded-line-geometry](../components/embedded-line-geometry-1.0.0-chunks.md) | A tuple defining the first index and the length of a chunk of vertices, forming a polyline/polygon.<br/>If indices is defined, the chunk refers to a segment of the indices array.<br/>Otherwise, the chunk refers to a segment of the vertices array.<br/>Chunks can overlap.<br/>Columns: offset, count | ✅ |
+| indices | [index-array-1](../elements/index-array-1-1.0.1.md) | An optional index array into the vertices.<br/>This is used to define chunks if the vertices list do not contain contiguous chunks. |  |
 
 
 #### Legend

--- a/docs/schemas/generated/flatmd/components/embedded-triangulated-mesh-2.0.0-parts.md
+++ b/docs/schemas/generated/flatmd/components/embedded-triangulated-mesh-2.0.0-parts.md
@@ -4,8 +4,8 @@ A structure defining chunks the mesh is composed of.
 | Property | Type | Description | Flags |
 |---|---|---|---|
 | attributes | [one-of-attribute](../components/one-of-attribute-1.1.0.md) | Attribute data. | [⬆️](../components/attribute-list-property-1.1.0.md) |
-| chunks | [index-array-2](../elements/index-array-2-1.0.1.md) | A tuple defining the first index and the length of a chunk.<br>If triangle_indices is defined, the chunk refers to a segment of the triangle_indices array.<br>Otherwise, the chunk refers to a segment of the triangles array.<br>Chunks do not have to include all triangles, and chunks can overlap.<br>Columns: offset, count | ✅ |
-| triangle_indices | [index-array-1](../elements/index-array-1-1.0.1.md) | An optional index array into the triangle indices set.<br>This is used to define chunks if the mesh triangle indices do not contain contiguous chunks. |  |
+| chunks | [index-array-2](../elements/index-array-2-1.0.1.md) | A tuple defining the first index and the length of a chunk.<br/>If triangle_indices is defined, the chunk refers to a segment of the triangle_indices array.<br/>Otherwise, the chunk refers to a segment of the triangles array.<br/>Chunks do not have to include all triangles, and chunks can overlap.<br/>Columns: offset, count | ✅ |
+| triangle_indices | [index-array-1](../elements/index-array-1-1.0.1.md) | An optional index array into the triangle indices set.<br/>This is used to define chunks if the mesh triangle indices do not contain contiguous chunks. |  |
 
 
 #### Legend

--- a/docs/schemas/generated/flatmd/components/embedded-triangulated-mesh-2.1.0-parts.md
+++ b/docs/schemas/generated/flatmd/components/embedded-triangulated-mesh-2.1.0-parts.md
@@ -4,8 +4,8 @@ A structure defining chunks the mesh is composed of.
 | Property | Type | Description | Flags |
 |---|---|---|---|
 | attributes | [one-of-attribute](../components/one-of-attribute-1.2.0.md) | Attribute data. | [⬆️](../components/attribute-list-property-1.2.0.md) |
-| chunks | [index-array-2](../elements/index-array-2-1.0.1.md) | A tuple defining the first index and the length of a chunk.<br>If triangle_indices is defined, the chunk refers to a segment of the triangle_indices array.<br>Otherwise, the chunk refers to a segment of the triangles array.<br>Chunks do not have to include all triangles, and chunks can overlap.<br>Columns: offset, count | ✅ |
-| triangle_indices | [index-array-1](../elements/index-array-1-1.0.1.md) | An optional index array into the triangle indices set.<br>This is used to define chunks if the mesh triangle indices do not contain contiguous chunks. |  |
+| chunks | [index-array-2](../elements/index-array-2-1.0.1.md) | A tuple defining the first index and the length of a chunk.<br/>If triangle_indices is defined, the chunk refers to a segment of the triangle_indices array.<br/>Otherwise, the chunk refers to a segment of the triangles array.<br/>Chunks do not have to include all triangles, and chunks can overlap.<br/>Columns: offset, count | ✅ |
+| triangle_indices | [index-array-1](../elements/index-array-1-1.0.1.md) | An optional index array into the triangle indices set.<br/>This is used to define chunks if the mesh triangle indices do not contain contiguous chunks. |  |
 
 
 #### Legend

--- a/docs/schemas/generated/flatmd/components/indices-attribute-1.1.0.md
+++ b/docs/schemas/generated/flatmd/components/indices-attribute-1.1.0.md
@@ -4,7 +4,7 @@ An attribute for a range of indices.
 | Property | Type | Description | Flags |
 |---|---|---|---|
 | name | String | The name of the attribute | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
-| key | String | An identifier of the attribute, used to keep track of the attribute when it is renamed.<br>The identifier must be unique within an attribute list. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
+| key | String | An identifier of the attribute, used to keep track of the attribute when it is renamed.<br/>The identifier must be unique within an attribute list. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
 | attribute_type | String | Type of the attribute. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
 | attribute_description | [attribute-description](../components/attribute-description-1.0.1.md) | The attribute description record. | [⬆️](../components/base-continuous-attribute-1.0.0.md) |
 | attribute_type | String |  | ✅ |

--- a/docs/schemas/generated/flatmd/components/integer-attribute-1.1.0.md
+++ b/docs/schemas/generated/flatmd/components/integer-attribute-1.1.0.md
@@ -4,7 +4,7 @@ An attribute for a range of integers.
 | Property | Type | Description | Flags |
 |---|---|---|---|
 | name | String | The name of the attribute | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
-| key | String | An identifier of the attribute, used to keep track of the attribute when it is renamed.<br>The identifier must be unique within an attribute list. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
+| key | String | An identifier of the attribute, used to keep track of the attribute when it is renamed.<br/>The identifier must be unique within an attribute list. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
 | attribute_type | String | Type of the attribute. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
 | attribute_description | [attribute-description](../components/attribute-description-1.0.1.md) | The attribute description record. | [⬆️](../components/base-continuous-attribute-1.0.0.md) |
 | attribute_type | String |  | ✅ |

--- a/docs/schemas/generated/flatmd/components/string-attribute-1.1.0.md
+++ b/docs/schemas/generated/flatmd/components/string-attribute-1.1.0.md
@@ -4,7 +4,7 @@ List of attributes that are just strings.
 | Property | Type | Description | Flags |
 |---|---|---|---|
 | name | String | The name of the attribute | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
-| key | String | An identifier of the attribute, used to keep track of the attribute when it is renamed.<br>The identifier must be unique within an attribute list. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
+| key | String | An identifier of the attribute, used to keep track of the attribute when it is renamed.<br/>The identifier must be unique within an attribute list. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
 | attribute_type | String | Type of the attribute. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
 | attribute_description | [attribute-description](../components/attribute-description-1.0.1.md) | The attribute description record. | [⬆️](../components/base-continuous-attribute-1.0.0.md) |
 | attribute_type | String |  | ✅ |

--- a/docs/schemas/generated/flatmd/components/time-step-continuous-attribute-1.1.0.md
+++ b/docs/schemas/generated/flatmd/components/time-step-continuous-attribute-1.1.0.md
@@ -4,7 +4,7 @@ A component that represents elapsed time (sec, min, hours, months, etc.) since a
 | Property | Type | Description | Flags |
 |---|---|---|---|
 | name | String | The name of the attribute | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
-| key | String | An identifier of the attribute, used to keep track of the attribute when it is renamed.<br>The identifier must be unique within an attribute list. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
+| key | String | An identifier of the attribute, used to keep track of the attribute when it is renamed.<br/>The identifier must be unique within an attribute list. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
 | attribute_type | String | Type of the attribute. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
 | attribute_description | [attribute-description](../components/attribute-description-1.0.1.md) | The attribute description record. | [⬆️](../components/base-continuous-attribute-1.0.0.md) |
 | attribute_type | String |  | ✅ |

--- a/docs/schemas/generated/flatmd/components/time-step-date-time-attribute-1.1.0.md
+++ b/docs/schemas/generated/flatmd/components/time-step-date-time-attribute-1.1.0.md
@@ -4,7 +4,7 @@ An attribute for a range of timestamps in a time series.
 | Property | Type | Description | Flags |
 |---|---|---|---|
 | name | String | The name of the attribute | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
-| key | String | An identifier of the attribute, used to keep track of the attribute when it is renamed.<br>The identifier must be unique within an attribute list. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
+| key | String | An identifier of the attribute, used to keep track of the attribute when it is renamed.<br/>The identifier must be unique within an attribute list. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
 | attribute_type | String | Type of the attribute. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
 | attribute_description | [attribute-description](../components/attribute-description-1.0.1.md) | The attribute description record. | [⬆️](../components/base-continuous-attribute-1.0.0.md) |
 | attribute_type | String |  | ✅ |

--- a/docs/schemas/generated/flatmd/components/vector-attribute-1.0.0.md
+++ b/docs/schemas/generated/flatmd/components/vector-attribute-1.0.0.md
@@ -4,7 +4,7 @@ An attribute containing an N-dimensional vector.
 | Property | Type | Description | Flags |
 |---|---|---|---|
 | name | String | The name of the attribute | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
-| key | String | An identifier of the attribute, used to keep track of the attribute when it is renamed.<br>The identifier must be unique within an attribute list. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
+| key | String | An identifier of the attribute, used to keep track of the attribute when it is renamed.<br/>The identifier must be unique within an attribute list. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
 | attribute_type | String | Type of the attribute. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
 | attribute_description | [attribute-description](../components/attribute-description-1.0.1.md) | The attribute description record. | [⬆️](../components/base-continuous-attribute-1.0.0.md) |
 | attribute_type | String |  | ✅ |

--- a/docs/schemas/generated/flatmd/objects/line-segments-2.0.0-parts.md
+++ b/docs/schemas/generated/flatmd/objects/line-segments-2.0.0-parts.md
@@ -5,7 +5,7 @@ Attributes are associated with each chunk.
 | Property | Type | Description | Flags |
 |---|---|---|---|
 | attributes | [one-of-attribute](../components/one-of-attribute-1.1.0.md) | Attribute data. | [⬆️](../components/attribute-list-property-1.1.0.md) |
-| chunks | [index-array-2](../elements/index-array-2-1.0.1.md) | A list of chunks of segments.<br>A chunk consists of consecutive segments, defined by the index of the first segment and the number of segments.<br>Chunks do not have to include all segments, and chunks can overlap.<br>Columns: offset, count | ✅ |
+| chunks | [index-array-2](../elements/index-array-2-1.0.1.md) | A list of chunks of segments.<br/>A chunk consists of consecutive segments, defined by the index of the first segment and the number of segments.<br/>Chunks do not have to include all segments, and chunks can overlap.<br/>Columns: offset, count | ✅ |
 
 
 #### Legend

--- a/docs/schemas/generated/flatmd/objects/line-segments-2.1.0-parts.md
+++ b/docs/schemas/generated/flatmd/objects/line-segments-2.1.0-parts.md
@@ -5,7 +5,7 @@ Attributes are associated with each chunk.
 | Property | Type | Description | Flags |
 |---|---|---|---|
 | attributes | [one-of-attribute](../components/one-of-attribute-1.2.0.md) | Attribute data. | [⬆️](../components/attribute-list-property-1.2.0.md) |
-| chunks | [index-array-2](../elements/index-array-2-1.0.1.md) | A list of chunks of segments.<br>A chunk consists of consecutive segments, defined by the index of the first segment and the number of segments.<br>Chunks do not have to include all segments, and chunks can overlap.<br>Columns: offset, count | ✅ |
+| chunks | [index-array-2](../elements/index-array-2-1.0.1.md) | A list of chunks of segments.<br/>A chunk consists of consecutive segments, defined by the index of the first segment and the number of segments.<br/>Chunks do not have to include all segments, and chunks can overlap.<br/>Columns: offset, count | ✅ |
 
 
 #### Legend

--- a/docs/schemas/generated/flatmd/objects/line-segments-2.2.0-parts.md
+++ b/docs/schemas/generated/flatmd/objects/line-segments-2.2.0-parts.md
@@ -5,7 +5,7 @@ Attributes are associated with each chunk.
 | Property | Type | Description | Flags |
 |---|---|---|---|
 | attributes | [one-of-attribute](../components/one-of-attribute-1.2.0.md) | Attribute data. | [⬆️](../components/attribute-list-property-1.2.0.md) |
-| chunks | [index-array-2](../elements/index-array-2-1.0.1.md) | A list of chunks of segments.<br>A chunk consists of consecutive segments, defined by the index of the first segment and the number of segments.<br>Chunks do not have to include all segments, and chunks can overlap.<br>Columns: offset, count | ✅ |
+| chunks | [index-array-2](../elements/index-array-2-1.0.1.md) | A list of chunks of segments.<br/>A chunk consists of consecutive segments, defined by the index of the first segment and the number of segments.<br/>Chunks do not have to include all segments, and chunks can overlap.<br/>Columns: offset, count | ✅ |
 
 
 #### Legend

--- a/docs/schemas/generated/flatmd/objects/triangle-mesh-2.0.0-edges-edge_parts.md
+++ b/docs/schemas/generated/flatmd/objects/triangle-mesh-2.0.0-edges-edge_parts.md
@@ -4,7 +4,7 @@ A structure defining edge chunks of the mesh.
 | Property | Type | Description | Flags |
 |---|---|---|---|
 | attributes | [one-of-attribute](../components/one-of-attribute-1.1.0.md) | Attribute data. | [⬆️](../components/attribute-list-property-1.1.0.md) |
-| chunks | [index-array-2](../elements/index-array-2-1.0.1.md) | A tuple defining the first index and the length of a chunk.<br>The chunk refers to a segment of the edges array.<br>Chunks do not have to include all edges, and chunks can overlap.<br>Columns: offset, count | ✅ |
+| chunks | [index-array-2](../elements/index-array-2-1.0.1.md) | A tuple defining the first index and the length of a chunk.<br/>The chunk refers to a segment of the edges array.<br/>Chunks do not have to include all edges, and chunks can overlap.<br/>Columns: offset, count | ✅ |
 
 
 #### Legend

--- a/docs/schemas/generated/flatmd/objects/triangle-mesh-2.1.0-edges-edge_parts.md
+++ b/docs/schemas/generated/flatmd/objects/triangle-mesh-2.1.0-edges-edge_parts.md
@@ -4,7 +4,7 @@ A structure defining edge chunks of the mesh.
 | Property | Type | Description | Flags |
 |---|---|---|---|
 | attributes | [one-of-attribute](../components/one-of-attribute-1.2.0.md) | Attribute data. | [⬆️](../components/attribute-list-property-1.2.0.md) |
-| chunks | [index-array-2](../elements/index-array-2-1.0.1.md) | A tuple defining the first index and the length of a chunk.<br>The chunk refers to a segment of the edges array.<br>Chunks do not have to include all edges, and chunks can overlap.<br>Columns: offset, count | ✅ |
+| chunks | [index-array-2](../elements/index-array-2-1.0.1.md) | A tuple defining the first index and the length of a chunk.<br/>The chunk refers to a segment of the edges array.<br/>Chunks do not have to include all edges, and chunks can overlap.<br/>Columns: offset, count | ✅ |
 
 
 #### Legend

--- a/docs/schemas/generated/flatmd/objects/triangle-mesh-2.2.0-edges-edge_parts.md
+++ b/docs/schemas/generated/flatmd/objects/triangle-mesh-2.2.0-edges-edge_parts.md
@@ -4,7 +4,7 @@ A structure defining edge chunks of the mesh.
 | Property | Type | Description | Flags |
 |---|---|---|---|
 | attributes | [one-of-attribute](../components/one-of-attribute-1.2.0.md) | Attribute data. | [⬆️](../components/attribute-list-property-1.2.0.md) |
-| chunks | [index-array-2](../elements/index-array-2-1.0.1.md) | A tuple defining the first index and the length of a chunk.<br>The chunk refers to a segment of the edges array.<br>Chunks do not have to include all edges, and chunks can overlap.<br>Columns: offset, count | ✅ |
+| chunks | [index-array-2](../elements/index-array-2-1.0.1.md) | A tuple defining the first index and the length of a chunk.<br/>The chunk refers to a segment of the edges array.<br/>Chunks do not have to include all edges, and chunks can overlap.<br/>Columns: offset, count | ✅ |
 
 
 #### Legend

--- a/docs/schemas/generated/flatmd/objects/triangle-mesh-2.3.0-edges-edge_parts.md
+++ b/docs/schemas/generated/flatmd/objects/triangle-mesh-2.3.0-edges-edge_parts.md
@@ -4,7 +4,7 @@ A structure defining edge chunks of the mesh.
 | Property | Type | Description | Flags |
 |---|---|---|---|
 | attributes | [one-of-attribute](../components/one-of-attribute-1.2.0.md) | Attribute data. | [⬆️](../components/attribute-list-property-1.2.0.md) |
-| chunks | [index-array-2](../elements/index-array-2-1.0.1.md) | A tuple defining the first index and the length of a chunk.<br>The chunk refers to a segment of the edges array.<br>Chunks do not have to include all edges, and chunks can overlap.<br>Columns: offset, count | ✅ |
+| chunks | [index-array-2](../elements/index-array-2-1.0.1.md) | A tuple defining the first index and the length of a chunk.<br/>The chunk refers to a segment of the edges array.<br/>Chunks do not have to include all edges, and chunks can overlap.<br/>Columns: offset, count | ✅ |
 
 
 #### Legend

--- a/tools/code_generator/markdown_generator.py
+++ b/tools/code_generator/markdown_generator.py
@@ -67,7 +67,7 @@ class MarkdownGenerator:
         for prop in cls.props:
             name = prop.name
             type_ = self._get_type(prop)
-            description = (prop.description or "").replace("|", "\\|").replace("\r\n", "\n").replace("\n", "<br>")
+            description = (prop.description or "").replace("|", "\\|").replace("\r\n", "\n").replace("\n", "<br/>")
             flags = self._get_flags(prop, inherited)
             yield f"| {name} | {type_} | {description} | {flags} |\n"
 


### PR DESCRIPTION
<!--
Thank you for taking the time to make a pull request.

Please review our [contribution guide](https://github.com/seequentevo/evo-schemas/blob/main/CONTRIBUTING.md) and our
[code of conduct](https://github.com/seequentevo/evo-schemas/blob/main/CONTRIBUTING.md) before opening your first
pull request.

By making a pull request, you confirm you agree to our Contributor License Agreement (CLA).
-->

## Description
In a recent change to fix some table formatting, I added BR tags, unfortunately this was missing the self closing "/" which causes problems in some upstream `.md` parsers. The main fix is in this commit:
https://github.com/SeequentEvo/evo-schemas/commit/bb0363aae4ee221f315040dcf840d5b867f024fb

While the updated markdown files are in this commit:
https://github.com/SeequentEvo/evo-schemas/commit/7b95efd38b3924170cc95bc3efdc6fd4d91b6820

<!-- Describe your proposed changes in detail -->

## Checklist

- [x] I have read the contributing guide and the code of conduct
