### PR TITLE
Allow BlockModelCategoryAttribute to accept integers and floats

### DIFF
--- a/schema/components/block-model-category-attribute/1.0.1/block-model-category-attribute.schema.json
+++ b/schema/components/block-model-category-attribute/1.0.1/block-model-category-attribute.schema.json
@@ -1,0 +1,39 @@
+{
+  "$id": "/components/block-model-category-attribute/1.0.0/block-model-category-attribute.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "A block model category/string attribute stored by the Block Model Service.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "/components/base-category-attribute/1.0.0/base-category-attribute.schema.json"
+    },
+    {
+      "properties": {
+        "attribute_type": {
+          "description": "The data type of the attribute as stored in the Block Model Service.",
+          "enum": [
+            "Boolean",
+            "Int8",
+            "Int16",
+            "Int32",
+            "Int64",
+            "UInt8",
+            "UInt16",
+            "UInt32",
+            "UInt64",
+            "Utf8"
+          ]
+        },
+        "block_model_column_uuid": {
+          "description": "The unique ID of the attribute on the block model.",
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    }
+  ],
+  "required": [
+    "attribute_type",
+    "block_model_column_uuid"
+  ]
+}

--- a/schema/components/block-model-category-attribute/1.0.1/block-model-category-attribute.schema.json
+++ b/schema/components/block-model-category-attribute/1.0.1/block-model-category-attribute.schema.json
@@ -13,6 +13,9 @@
           "description": "The data type of the attribute as stored in the Block Model Service.",
           "enum": [
             "Boolean",
+            "Float16",
+            "Float32",
+            "Float64",
             "Int8",
             "Int16",
             "Int32",

--- a/schema/components/block-model-category-attribute/1.0.1/block-model-category-attribute.schema.json
+++ b/schema/components/block-model-category-attribute/1.0.1/block-model-category-attribute.schema.json
@@ -1,7 +1,7 @@
 {
   "$id": "/components/block-model-category-attribute/1.0.0/block-model-category-attribute.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "description": "A block model category/string attribute stored by the Block Model Service.",
+  "description": "A block model category (string, boolean or number) attribute stored by the Block Model Service.",
   "type": "object",
   "allOf": [
     {


### PR DESCRIPTION
<!--
Thank you for taking the time to make a pull request.

Please review our [contribution guide](https://github.com/seequentevo/evo-schemas/blob/main/CONTRIBUTING.md) and our
[code of conduct](https://github.com/seequentevo/evo-schemas/blob/main/CONTRIBUTING.md) before opening your first
pull request.

By making a pull request, you confirm you agree to our Contributor License Agreement (CLA).
-->

## Description

Allow `BlockModelCategoryAttribute` to accept Integers and Unsigned-Integers, introduces V1.0.1

## Checklist

- [x] I have read the contributing guide and the code of conduct
