### PR TITLE
Add 'count' as a dimenssionless unit

### DIFF
--- a/schema/elements/unit/1.0.1/categories/unit-dimensionless.schema.json
+++ b/schema/elements/unit/1.0.1/categories/unit-dimensionless.schema.json
@@ -6,6 +6,7 @@
   "type": "string",
   "enum": [
     "%",
+    "count",
     "ppk",
     "ppm",
     "Euc",


### PR DESCRIPTION
<!--
Thank you for taking the time to make a pull request.

Please review our [contribution guide](https://github.com/seequentevo/evo-schemas/blob/main/CONTRIBUTING.md) and our
[code of conduct](https://github.com/seequentevo/evo-schemas/blob/main/CONTRIBUTING.md) before opening your first
pull request.

By making a pull request, you confirm you agree to our Contributor License Agreement (CLA).
-->

## Description

Add `count` as in "amount-of-something" as a dimensionless Unit. 

## Checklist

- [x] I have read the contributing guide and the code of conduct
