### PR TITLE
Add block model attribute differentiator

### DIFF
--- a/docs/schemas/components/block-model-attribute.md
+++ b/docs/schemas/components/block-model-attribute.md
@@ -1,15 +1,16 @@
 import SchemaUri from '@theme/SchemaUri';
-import FlatProperties from '../generated/flatmd/components/block-model-attribute-1.1.0.md';
+import FlatProperties from '../generated/flatmd/components/block-model-attribute-2.0.0.md';
 
 # block-model-attribute
 
-<SchemaUri uri="schema/components/block-model-attribute/1.1.0/block-model-attribute.schema.json" />
+<SchemaUri uri="schema/components/block-model-attribute/2.0.0/block-model-attribute.schema.json" />
 
 A block model attribute extends the standard attribute system for use with block model data. Block model
 attributes accommodate the variable-length sub-block structure of block models.
 
 This component composes [base-continuous-attribute](base-continuous-attribute.md) and adds block-model-specific
-value storage.
+value storage. Its `attribute_class` is always `continuous`, which discriminates it from
+[block-model-category-attribute](block-model-category-attribute.md) when both share the same `attribute_type`.
 
 **Used by:** block-model.
 

--- a/docs/schemas/components/block-model-category-attribute.md
+++ b/docs/schemas/components/block-model-category-attribute.md
@@ -1,14 +1,15 @@
 import SchemaUri from '@theme/SchemaUri';
-import FlatProperties from '../generated/flatmd/components/block-model-category-attribute-1.1.0.md';
+import FlatProperties from '../generated/flatmd/components/block-model-category-attribute-2.0.0.md';
 
 # block-model-category-attribute
 
-<SchemaUri uri="schema/components/block-model-category-attribute/1.1.0/block-model-category-attribute.schema.json" />
+<SchemaUri uri="schema/components/block-model-category-attribute/2.0.0/block-model-category-attribute.schema.json" />
 
 A block model category attribute extends the categorical attribute system for use with block model data.
 
 This component composes [base-category-attribute](base-category-attribute.md) and [category-data](category-data.md)
-with block-model-specific value storage.
+with block-model-specific value storage. Its `attribute_class` is always `category`, which discriminates it from
+[block-model-attribute](block-model-attribute.md) when both share the same `attribute_type`.
 
 **Used by:** block-model.
 

--- a/examples/2.0.0/components/block-model-attribute.json
+++ b/examples/2.0.0/components/block-model-attribute.json
@@ -2,6 +2,7 @@
   "$schema": "/components/block-model-attribute/2.0.0/block-model-attribute.schema.json",
   "name": "AU",
   "key": "f1b1a3b0-1b9b-4b6c-9b6b-3b4f1d2b0b0b",
+  "attribute_class": "continuous",
   "attribute_type": "Float32",
   "block_model_column_uuid": "f1b1a3b0-1b9b-4b6c-9b6b-3b4f1d2b0b0b",
   "attribute_description": {

--- a/examples/2.0.0/components/block-model-attribute.json
+++ b/examples/2.0.0/components/block-model-attribute.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "/components/block-model-attribute/2.0.0/block-model-attribute.schema.json",
+  "name": "AU",
+  "key": "f1b1a3b0-1b9b-4b6c-9b6b-3b4f1d2b0b0b",
+  "attribute_type": "Float32",
+  "block_model_column_uuid": "f1b1a3b0-1b9b-4b6c-9b6b-3b4f1d2b0b0b",
+  "attribute_description": {
+    "discipline": "Geochemistry",
+    "type": "Gold",
+    "unit": "%"
+  }
+}

--- a/examples/2.0.0/components/block-model-category-attribute.json
+++ b/examples/2.0.0/components/block-model-category-attribute.json
@@ -2,6 +2,7 @@
   "$schema": "/components/block-model-category-attribute/2.0.0/block-model-category-attribute.schema.json",
   "name": "Rock",
   "key": "f1b1a3b0-1b9b-4b6c-9b6b-3b4f1d2b0b0b",
+  "attribute_class": "category",
   "attribute_type": "Utf8",
   "block_model_column_uuid": "f1b1a3b0-1b9b-4b6c-9b6b-3b4f1d2b0b0b",
   "attribute_description": {

--- a/examples/2.0.0/components/block-model-category-attribute.json
+++ b/examples/2.0.0/components/block-model-category-attribute.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "/components/block-model-category-attribute/2.0.0/block-model-category-attribute.schema.json",
+  "name": "Rock",
+  "key": "f1b1a3b0-1b9b-4b6c-9b6b-3b4f1d2b0b0b",
+  "attribute_type": "Utf8",
+  "block_model_column_uuid": "f1b1a3b0-1b9b-4b6c-9b6b-3b4f1d2b0b0b",
+  "attribute_description": {
+    "discipline": "Geology",
+    "type": "Lithology"
+  }
+}

--- a/examples/2.0.0/objects/block-model-1.json
+++ b/examples/2.0.0/objects/block-model-1.json
@@ -44,6 +44,7 @@
       "name": "AU",
       "key": "00000000-0000-0000-0000-000000000003",
       "block_model_column_uuid": "00000000-0000-0000-0000-000000000003",
+      "attribute_class": "continuous",
       "attribute_type": "Float16",
       "attribute_description": {
         "discipline": "Geochemistry",

--- a/examples/2.0.0/objects/block-model-1.json
+++ b/examples/2.0.0/objects/block-model-1.json
@@ -1,0 +1,57 @@
+{
+  "schema": "/objects/block-model/2.0.0/block-model.schema.json",
+  "name": "Example Block Model",
+  "uuid": "00000000-0000-0000-0000-000000000000",
+  "description": "This is example data to ensure the object validates properly.",
+  "bounding_box": {
+    "min_x": 0,
+    "max_x": 15,
+    "min_y": 0,
+    "max_y": 15,
+    "min_z": 0,
+    "max_z": 50.0
+  },
+  "coordinate_reference_system": {
+    "epsg_code": 1024
+  },
+  "block_model_uuid": "00000000-0000-0000-0000-000000000001",
+  "block_model_version_uuid": "00000000-0000-0000-0000-000000000002",
+  "geometry": {
+    "model_type": "regular",
+    "origin": [
+      0.0,
+      0.0,
+      0.0
+    ],
+    "n_blocks": [
+      10,
+      10,
+      20
+    ],
+    "block_size": [
+      1.5,
+      1.5,
+      2.5
+    ],
+    "rotation": {
+      "dip_azimuth": 0.0,
+      "dip": 0.0,
+      "pitch": 0.0
+    }
+  },
+  "attributes": [
+    {
+      "name": "AU",
+      "key": "00000000-0000-0000-0000-000000000003",
+      "block_model_column_uuid": "00000000-0000-0000-0000-000000000003",
+      "attribute_type": "Float16",
+      "attribute_description": {
+        "discipline": "Geochemistry",
+        "type": "Gold",
+        "unit": "%"
+      }
+    }
+  ],
+  "tags": {},
+  "extensions": {}
+}

--- a/examples/2.0.0/objects/block-model-2.json
+++ b/examples/2.0.0/objects/block-model-2.json
@@ -49,6 +49,7 @@
       "name": "example_attr",
       "key": "00000000-0000-0000-0000-000000000004",
       "block_model_column_uuid": "00000000-0000-0000-0000-000000000004",
+      "attribute_class": "category",
       "attribute_type": "Boolean"
     }
   ],

--- a/examples/2.0.0/objects/block-model-2.json
+++ b/examples/2.0.0/objects/block-model-2.json
@@ -1,0 +1,57 @@
+{
+  "schema": "/objects/block-model/2.0.0/block-model.schema.json",
+  "name": "Example Block Model",
+  "uuid": "00000000-0000-0000-0000-000000000001",
+  "description": "This is example data to ensure the object validates properly.",
+  "bounding_box": {
+    "min_x": 0,
+    "max_x": 15,
+    "min_y": 0,
+    "max_y": 15,
+    "min_z": 0,
+    "max_z": 50.0
+  },
+  "coordinate_reference_system": {
+    "epsg_code": 1024
+  },
+  "block_model_uuid": "00000000-0000-0000-0000-000000000002",
+  "block_model_version_uuid": "00000000-0000-0000-0000-000000000004",
+  "geometry": {
+    "model_type": "flexible",
+    "origin": [
+      0.0,
+      0.0,
+      0.0
+    ],
+    "n_parent_blocks": [
+      10,
+      10,
+      20
+    ],
+    "parent_block_size": [
+      1.5,
+      1.5,
+      2.5
+    ],
+    "n_subblocks_per_parent": [
+      15,
+      64,
+      21
+    ],
+    "rotation": {
+      "dip_azimuth": 90.0,
+      "dip": 45.0,
+      "pitch": 15.0
+    }
+  },
+  "attributes": [
+    {
+      "name": "example_attr",
+      "key": "00000000-0000-0000-0000-000000000004",
+      "block_model_column_uuid": "00000000-0000-0000-0000-000000000004",
+      "attribute_type": "Boolean"
+    }
+  ],
+  "tags": {},
+  "extensions": {}
+}

--- a/examples/2.0.0/objects/block-model-3.json
+++ b/examples/2.0.0/objects/block-model-3.json
@@ -1,0 +1,57 @@
+{
+  "schema": "/objects/block-model/2.0.0/block-model.schema.json",
+  "name": "Example Block Model",
+  "uuid": "00000000-0000-0000-0000-000000000002",
+  "description": "This is example data to ensure the object validates properly.",
+  "bounding_box": {
+    "min_x": 0,
+    "max_x": 15,
+    "min_y": 0,
+    "max_y": 15,
+    "min_z": 0,
+    "max_z": 50.0
+  },
+  "coordinate_reference_system": {
+    "epsg_code": 1024
+  },
+  "block_model_uuid": "00000000-0000-0000-0000-000000000003",
+  "block_model_version_uuid": "00000000-0000-0000-0000-000000000008",
+  "geometry": {
+    "model_type": "fully-sub-blocked",
+    "origin": [
+      0.0,
+      0.0,
+      0.0
+    ],
+    "n_parent_blocks": [
+      10,
+      10,
+      20
+    ],
+    "parent_block_size": [
+      1.5,
+      1.5,
+      2.5
+    ],
+    "n_subblocks_per_parent": [
+      8,
+      20,
+      15
+    ],
+    "rotation": {
+      "dip_azimuth": 270.0,
+      "dip": 5.0,
+      "pitch": 150.0
+    }
+  },
+  "attributes": [
+    {
+      "name": "example_attr",
+      "key": "00000000-0000-0000-0000-000000000016",
+      "block_model_column_uuid": "00000000-0000-0000-0000-000000000016",
+      "attribute_type": "Utf8"
+    }
+  ],
+  "tags": {},
+  "extensions": {}
+}

--- a/examples/2.0.0/objects/block-model-3.json
+++ b/examples/2.0.0/objects/block-model-3.json
@@ -49,6 +49,7 @@
       "name": "example_attr",
       "key": "00000000-0000-0000-0000-000000000016",
       "block_model_column_uuid": "00000000-0000-0000-0000-000000000016",
+      "attribute_class": "category",
       "attribute_type": "Utf8"
     }
   ],

--- a/examples/2.0.0/objects/block-model-4.json
+++ b/examples/2.0.0/objects/block-model-4.json
@@ -49,6 +49,7 @@
       "name": "example_attr",
       "key": "00000000-0000-0000-0000-000000000032",
       "block_model_column_uuid": "00000000-0000-0000-0000-000000000032",
+      "attribute_class": "continuous",
       "attribute_type": "Date32"
     }
   ],

--- a/examples/2.0.0/objects/block-model-4.json
+++ b/examples/2.0.0/objects/block-model-4.json
@@ -1,0 +1,57 @@
+{
+  "schema": "/objects/block-model/2.0.0/block-model.schema.json",
+  "name": "Example Block Model",
+  "uuid": "00000000-0000-0000-0000-000000000003",
+  "description": "This is example data to ensure the object validates properly.",
+  "bounding_box": {
+    "min_x": 0,
+    "max_x": 15,
+    "min_y": 0,
+    "max_y": 15,
+    "min_z": 0,
+    "max_z": 50.0
+  },
+  "coordinate_reference_system": {
+    "epsg_code": 1024
+  },
+  "block_model_uuid": "00000000-0000-0000-0000-000000000004",
+  "block_model_version_uuid": "00000000-0000-0000-0000-000000000016",
+  "geometry": {
+    "model_type": "variable-octree",
+    "origin": [
+      0.0,
+      0.0,
+      0.0
+    ],
+    "n_parent_blocks": [
+      10,
+      10,
+      20
+    ],
+    "parent_block_size": [
+      1.5,
+      1.5,
+      2.5
+    ],
+    "n_subblocks_per_parent": [
+      8,
+      16,
+      4
+    ],
+    "rotation": {
+      "dip_azimuth": 70.0,
+      "dip": 50.0,
+      "pitch": 1.0
+    }
+  },
+  "attributes": [
+    {
+      "name": "example_attr",
+      "key": "00000000-0000-0000-0000-000000000032",
+      "block_model_column_uuid": "00000000-0000-0000-0000-000000000032",
+      "attribute_type": "Date32"
+    }
+  ],
+  "tags": {},
+  "extensions": {}
+}

--- a/schema/components/block-model-attribute/2.0.0/block-model-attribute.schema.json
+++ b/schema/components/block-model-attribute/2.0.0/block-model-attribute.schema.json
@@ -9,6 +9,10 @@
     },
     {
       "properties": {
+        "attribute_class": {
+          "description": "Discriminator identifying the attribute variant. Always \"continuous\" for a continuous attribute.",
+          "const": "continuous"
+        },
         "attribute_type": {
           "description": "The data type of the attribute as stored in the Block Model Service.",
           "enum": [
@@ -36,6 +40,7 @@
     }
   ],
   "required": [
+    "attribute_class",
     "attribute_type",
     "block_model_column_uuid"
   ]

--- a/schema/components/block-model-attribute/2.0.0/block-model-attribute.schema.json
+++ b/schema/components/block-model-attribute/2.0.0/block-model-attribute.schema.json
@@ -1,0 +1,42 @@
+{
+  "$id": "/components/block-model-attribute/2.0.0/block-model-attribute.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "A block model attribute.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "/components/base-continuous-attribute/1.1.0/base-continuous-attribute.schema.json"
+    },
+    {
+      "properties": {
+        "attribute_type": {
+          "description": "The data type of the attribute as stored in the Block Model Service.",
+          "enum": [
+            "Int8",
+            "Int16",
+            "Int32",
+            "Int64",
+            "UInt8",
+            "UInt16",
+            "UInt32",
+            "UInt64",
+            "Float16",
+            "Float32",
+            "Float64",
+            "Date32",
+            "Timestamp"
+          ]
+        },
+        "block_model_column_uuid": {
+          "description": "The unique ID of the attribute on the block model.",
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    }
+  ],
+  "required": [
+    "attribute_type",
+    "block_model_column_uuid"
+  ]
+}

--- a/schema/components/block-model-category-attribute/2.0.0/block-model-category-attribute.schema.json
+++ b/schema/components/block-model-category-attribute/2.0.0/block-model-category-attribute.schema.json
@@ -9,6 +9,10 @@
     },
     {
       "properties": {
+        "attribute_class": {
+          "description": "Discriminator identifying the attribute variant. Always \"category\" for a category attribute.",
+          "const": "category"
+        },
         "attribute_type": {
           "description": "The data type of the attribute as stored in the Block Model Service.",
           "enum": [
@@ -36,6 +40,7 @@
     }
   ],
   "required": [
+    "attribute_class",
     "attribute_type",
     "block_model_column_uuid"
   ]

--- a/schema/components/block-model-category-attribute/2.0.0/block-model-category-attribute.schema.json
+++ b/schema/components/block-model-category-attribute/2.0.0/block-model-category-attribute.schema.json
@@ -1,0 +1,39 @@
+{
+  "$id": "/components/block-model-category-attribute/2.0.0/block-model-category-attribute.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "A block model category/string attribute stored by the Block Model Service.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "/components/base-category-attribute/1.0.0/base-category-attribute.schema.json"
+    },
+    {
+      "properties": {
+        "attribute_type": {
+          "description": "The data type of the attribute as stored in the Block Model Service.",
+          "enum": [
+            "Boolean",
+            "Utf8",
+            "Int8",
+            "Int16",
+            "Int32",
+            "Int64",
+            "UInt8",
+            "UInt16",
+            "UInt32",
+            "UInt64",
+          ]
+        },
+        "block_model_column_uuid": {
+          "description": "The unique ID of the attribute on the block model.",
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    }
+  ],
+  "required": [
+    "attribute_type",
+    "block_model_column_uuid"
+  ]
+}

--- a/schema/components/block-model-category-attribute/2.0.0/block-model-category-attribute.schema.json
+++ b/schema/components/block-model-category-attribute/2.0.0/block-model-category-attribute.schema.json
@@ -22,6 +22,9 @@
             "UInt16",
             "UInt32",
             "UInt64",
+            "Float16",
+            "Float32",
+            "Float64",
           ]
         },
         "block_model_column_uuid": {

--- a/schema/components/block-model-category-attribute/2.0.0/block-model-category-attribute.schema.json
+++ b/schema/components/block-model-category-attribute/2.0.0/block-model-category-attribute.schema.json
@@ -28,7 +28,7 @@
             "UInt64",
             "Float16",
             "Float32",
-            "Float64",
+            "Float64"
           ]
         },
         "block_model_column_uuid": {

--- a/schema/geoscience-objects.schema.json
+++ b/schema/geoscience-objects.schema.json
@@ -11,6 +11,9 @@
       "$ref": "/objects/block-model/1.1.0/block-model.schema.json"
     },
     {
+      "$ref": "/objects/block-model/2.0.0/block-model.schema.json"
+    },
+    {
       "$ref": "/objects/design-geometry/1.0.1/design-geometry.schema.json"
     },
     {

--- a/schema/objects/block-model/2.0.0/block-model.schema.json
+++ b/schema/objects/block-model/2.0.0/block-model.schema.json
@@ -1,0 +1,65 @@
+{
+  "$id": "/objects/block-model/2.0.0/block-model.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "A reference to a block model stored in the Block Model Service.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "/components/base-spatial-data-properties/1.1.0/base-spatial-data-properties.schema.json"
+    },
+    {
+      "properties": {
+        "schema": {
+          "const": "/objects/block-model/2.0.0/block-model.schema.json"
+        },
+        "block_model_uuid": {
+          "description": "The unique ID of the block model in the Block Model Service.",
+          "type": "string",
+          "format": "uuid"
+        },
+        "block_model_version_uuid": {
+          "description": "The unique ID of this version of the block model in the Block Model Service.",
+          "type": "string",
+          "format": "uuid"
+        },
+        "geometry": {
+          "description": "The geometry (including subblocking parameters, if applicable) of the block model.",
+          "oneOf": [
+            {
+              "$ref": "/components/block-model-flexible-structure/1.0.0/block-model-flexible-structure.schema.json"
+            },
+            {
+              "$ref": "/components/block-model-fully-subblocked-structure/1.0.0/block-model-fully-subblocked-structure.schema.json"
+            },
+            {
+              "$ref": "/components/block-model-regular-structure/1.0.0/block-model-regular-structure.schema.json"
+            },
+            {
+              "$ref": "/components/block-model-variable-octree-structure/1.0.0/block-model-variable-octree-structure.schema.json"
+            }
+          ]
+        },
+        "attributes": {
+          "description": "The attributes found on this version of the block model.",
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "/components/block-model-attribute/2.0.0/block-model-attribute.schema.json"
+              },
+              {
+                "$ref": "/components/block-model-category-attribute/2.0.0/block-model-category-attribute.schema.json"
+              }
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "required": [
+    "schema",
+    "block_model_uuid",
+    "geometry"
+  ],
+  "unevaluatedProperties": false
+}


### PR DESCRIPTION
<!--
Thank you for taking the time to make a pull request.

Please review our [contribution guide](https://github.com/seequentevo/evo-schemas/blob/main/CONTRIBUTING.md) and our
[code of conduct](https://github.com/seequentevo/evo-schemas/blob/main/CONTRIBUTING.md) before opening your first
pull request.

By making a pull request, you confirm you agree to our Contributor License Agreement (CLA).
-->

## Description
**Summary**

**Problem:** adding integer (and now float) types to  block-model-category-attribute  made the  attributes   oneOf  ambiguous —  attribute_type  and  unit  could no longer distinguish continuous vs category attributes.

**Solution**: an explicit discriminator field  attribute_class  ( "continuous"  |  "category" ), required on each variant — the JSON-Schema-native equivalent of an OpenAPI discriminator. This is a breaking change (new required field), so per the versioning policy it's a MAJOR bump.

**Changes** (via  clone_schema.py , 2.0.0):

•  block-model-attribute/2.0.0  →  attribute_class  const  "continuous" , required
•  block-model-category-attribute/2.0.0  →  attribute_class  const  "category" , required (enum now includes Boolean, Utf8, Int*, UInt*, Float* per your edit)
•  block-model/2.0.0  object →  oneOf  references both 2.0.0 components
• Examples copied to  examples/2.0.0/  with  attribute_class  added
• Docs: bumped the two component pages to 2.0.0 + noted the discriminator
• Regenerated  geoscience-objects.schema.json  root

**Verification:**

• Full suite: 4369 passed, 0 failed, 149 (pre-existing) warnings
• Proved disambiguation:  Int32  +  continuous  → valid,  Int32  +  category  → valid (exactly one branch each), missing  attribute_class  → correctly rejected
• pre-commit hooks (json/format/root schema) pass


## Checklist

- [x] I have read the contributing guide and the code of conduct
