### PR TITLE
Merge block-model-attributes-category and block-model-attributes

### DIFF
--- a/docs/schemas/components/block-model-attribute.md
+++ b/docs/schemas/components/block-model-attribute.md
@@ -1,19 +1,22 @@
 import SchemaUri from '@theme/SchemaUri';
-import FlatProperties from '../generated/flatmd/components/block-model-attribute-1.1.0.md';
+import FlatProperties from '../generated/flatmd/components/block-model-attribute-1.2.0.md';
 
 # block-model-attribute
 
-<SchemaUri uri="schema/components/block-model-attribute/1.1.0/block-model-attribute.schema.json" />
+<SchemaUri uri="schema/components/block-model-attribute/1.2.0/block-model-attribute.schema.json" />
 
 A block model attribute extends the standard attribute system for use with block model data. Block model
 attributes accommodate the variable-length sub-block structure of block models.
 
 This component composes [base-continuous-attribute](base-continuous-attribute.md) and adds block-model-specific
-value storage.
+value storage. As of 1.2.0 it is the single attribute type used by the block-model object, covering both
+continuous and categorical attributes via its `attribute_type` (`Boolean` and `Utf8` alongside the numeric,
+date, and timestamp types).
 
 **Used by:** block-model.
 
-**See also:** [block-model-category-attribute](block-model-category-attribute.md) (categorical counterpart).
+**See also:** [block-model-category-attribute](block-model-category-attribute.md) (separate categorical
+attribute used by block-model 1.1.0 and earlier).
 
 ## Properties
 

--- a/docs/schemas/generated/flatmd/components/block-model-attribute-1.2.0.md
+++ b/docs/schemas/generated/flatmd/components/block-model-attribute-1.2.0.md
@@ -1,0 +1,20 @@
+### block-model-attribute (v1.2.0)
+A block model attribute stored by the Block Model Service. Covers both continuous and categorical attributes.
+
+| Property | Type | Description | Flags |
+|---|---|---|---|
+| name | String | The name of the attribute | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
+| key | String | An identifier of the attribute, used to keep track of the attribute when it is renamed.<br/>The identifier must be unique within an attribute list. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
+| attribute_type | String | Type of the attribute. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
+| attribute_description | [attribute-description](../components/attribute-description-1.1.0.md) | The attribute description record. | [⬆️](../components/base-continuous-attribute-1.1.0.md) |
+| attribute_type | String | The data type of the attribute as stored in the Block Model Service. | ✅ |
+| block_model_column_uuid | String | The unique ID of the attribute on the block model. | ✅ |
+
+
+#### Legend
+
+| Flag | Description |
+| --- | --- |
+| ⬆️ | Inherited property |
+| ✅ | Required property |
+

--- a/docs/schemas/generated/flatmd/objects/block-model-1.2.0-geometry.md
+++ b/docs/schemas/generated/flatmd/objects/block-model-1.2.0-geometry.md
@@ -1,0 +1,14 @@
+### block-model (v1.2.0)
+The geometry (including subblocking parameters, if applicable) of the block model.
+
+| Property | Type | Description | Flags |
+|---|---|---|---|
+
+
+#### Legend
+
+| Flag | Description |
+| --- | --- |
+| ⬆️ | Inherited property |
+| ✅ | Required property |
+

--- a/docs/schemas/generated/flatmd/objects/block-model-1.2.0.md
+++ b/docs/schemas/generated/flatmd/objects/block-model-1.2.0.md
@@ -1,0 +1,27 @@
+### block-model (v1.2.0)
+A reference to a block model stored in the Block Model Service.
+
+| Property | Type | Description | Flags |
+|---|---|---|---|
+| name | String | Name of the object. | [⬆️](../components/base-object-properties-1.1.0.md) ✅ |
+| uuid | [base-object-properties](../components/base-object-properties-1.1.0-uuid.md) | Identifier of the object. | [⬆️](../components/base-object-properties-1.1.0.md) ✅ |
+| description | String | Optional field for adding additional description to uniquely identify this object. | [⬆️](../components/base-object-properties-1.1.0.md) |
+| extensions | Object | Extended properties that may be associated to the object, but not specified in the schema | [⬆️](../components/base-object-properties-1.1.0.md) |
+| tags | Object | Key-value pairs of user-defined metadata | [⬆️](../components/base-object-properties-1.1.0.md) |
+| lineage | [lineage](../components/lineage-1.0.0.md) | Information about the history of the object | [⬆️](../components/base-object-properties-1.1.0.md) |
+| bounding_box | [bounding-box](../components/bounding-box-1.0.1.md) | Bounding box of the spatial data. | [⬆️](../components/base-spatial-data-properties-1.1.0.md) ✅ |
+| coordinate_reference_system | [crs](../components/crs-1.0.1.md) | Coordinate system of the spatial data | [⬆️](../components/base-spatial-data-properties-1.1.0.md) ✅ |
+| schema | String |  | ✅ |
+| block_model_uuid | String | The unique ID of the block model in the Block Model Service. | ✅ |
+| block_model_version_uuid | String | The unique ID of this version of the block model in the Block Model Service. |  |
+| geometry | [block-model](../objects/block-model-1.2.0-geometry.md) | The geometry (including subblocking parameters, if applicable) of the block model. | ✅ |
+| attributes | Array[[block-model-attribute](../components/block-model-attribute-1.2.0.md)] | The attributes found on this version of the block model. |  |
+
+
+#### Legend
+
+| Flag | Description |
+| --- | --- |
+| ⬆️ | Inherited property |
+| ✅ | Required property |
+

--- a/docs/schemas/generated/uml/block-model-1.2.0.mmd
+++ b/docs/schemas/generated/uml/block-model-1.2.0.mmd
@@ -1,0 +1,64 @@
+---
+config:
+    class:
+        hideEmptyMembersBox: true
+---
+
+classDiagram
+    class `components/base-object-properties-1.1.0`:::schemaComponent {
+        name: string
+        uuid: components/base-object-properties-1.1.0-uuid
+        description: string
+        extensions: object
+        tags: object
+        lineage: components/lineage-1.0.0
+    }
+    class `components/base-spatial-data-properties-1.1.0`:::schemaComponent {
+        name: string*
+        uuid: components/base-object-properties-1.1.0-uuid*
+        description: string*
+        extensions: object*
+        tags: object*
+        lineage: components/lineage-1.0.0*
+        bounding_box: components/bounding-box-1.0.1
+        coordinate_reference_system: components/crs-1.0.1
+    }
+    `components/base-object-properties-1.1.0` <|-- `components/base-spatial-data-properties-1.1.0`
+    class `objects/block-model-1.2.0`:::schemaObject {
+        name: string*
+        uuid: components/base-object-properties-1.1.0-uuid*
+        description: string*
+        extensions: object*
+        tags: object*
+        lineage: components/lineage-1.0.0*
+        bounding_box: components/bounding-box-1.0.1*
+        coordinate_reference_system: components/crs-1.0.1*
+        block_model_uuid: string
+        block_model_version_uuid: string
+        geometry: objects/block-model-1.2.0-geometry
+        attributes: array
+    }
+    `components/base-spatial-data-properties-1.1.0` <|-- `objects/block-model-1.2.0`
+    `components/base-object-properties-1.1.0` *-- `components/base-object-properties-1.1.0-uuid` : ref uuid*
+    `components/base-object-properties-1.1.0` *-- `components/lineage-1.0.0` : ref lineage*
+    `components/base-spatial-data-properties-1.1.0` *-- `components/bounding-box-1.0.1` : ref bounding_box*
+    `components/base-spatial-data-properties-1.1.0` *-- `components/crs-1.0.1` : ref coordinate_reference_system*
+    `objects/block-model-1.2.0` *-- `objects/block-model-1.2.0-geometry` : ref geometry*
+    class `components/base-object-properties-1.1.0-uuid`:::schemaImplicit {
+    }
+    class `components/lineage-1.0.0`:::schemaComponent {
+        self_link: string
+        events: array
+    }
+    class `components/bounding-box-1.0.1`:::schemaComponent {
+        min_x: number
+        max_x: number
+        min_y: number
+        max_y: number
+        min_z: number
+        max_z: number
+    }
+    class `components/crs-1.0.1`:::schemaComponent {
+    }
+    class `objects/block-model-1.2.0-geometry`:::schemaImplicit {
+    }

--- a/examples/1.2.0/components/block-model-attribute.json
+++ b/examples/1.2.0/components/block-model-attribute.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "/components/block-model-attribute/1.2.0/block-model-attribute.schema.json",
+  "name": "AU",
+  "key": "f1b1a3b0-1b9b-4b6c-9b6b-3b4f1d2b0b0b",
+  "attribute_type": "Float32",
+  "block_model_column_uuid": "f1b1a3b0-1b9b-4b6c-9b6b-3b4f1d2b0b0b",
+  "attribute_description": {
+    "discipline": "Geochemistry",
+    "type": "Gold",
+    "unit": "%"
+  }
+}

--- a/examples/1.2.0/objects/block-model-1.json
+++ b/examples/1.2.0/objects/block-model-1.json
@@ -1,0 +1,57 @@
+{
+  "schema": "/objects/block-model/1.2.0/block-model.schema.json",
+  "name": "Example Block Model",
+  "uuid": "00000000-0000-0000-0000-000000000000",
+  "description": "This is example data to ensure the object validates properly.",
+  "bounding_box": {
+    "min_x": 0,
+    "max_x": 15,
+    "min_y": 0,
+    "max_y": 15,
+    "min_z": 0,
+    "max_z": 50.0
+  },
+  "coordinate_reference_system": {
+    "epsg_code": 1024
+  },
+  "block_model_uuid": "00000000-0000-0000-0000-000000000001",
+  "block_model_version_uuid": "00000000-0000-0000-0000-000000000002",
+  "geometry": {
+    "model_type": "regular",
+    "origin": [
+      0.0,
+      0.0,
+      0.0
+    ],
+    "n_blocks": [
+      10,
+      10,
+      20
+    ],
+    "block_size": [
+      1.5,
+      1.5,
+      2.5
+    ],
+    "rotation": {
+      "dip_azimuth": 0.0,
+      "dip": 0.0,
+      "pitch": 0.0
+    }
+  },
+  "attributes": [
+    {
+      "name": "AU",
+      "key": "00000000-0000-0000-0000-000000000003",
+      "block_model_column_uuid": "00000000-0000-0000-0000-000000000003",
+      "attribute_type": "Float16",
+      "attribute_description": {
+        "discipline": "Geochemistry",
+        "type": "Gold",
+        "unit": "%"
+      }
+    }
+  ],
+  "tags": {},
+  "extensions": {}
+}

--- a/examples/1.2.0/objects/block-model-2.json
+++ b/examples/1.2.0/objects/block-model-2.json
@@ -1,0 +1,57 @@
+{
+  "schema": "/objects/block-model/1.2.0/block-model.schema.json",
+  "name": "Example Block Model",
+  "uuid": "00000000-0000-0000-0000-000000000001",
+  "description": "This is example data to ensure the object validates properly.",
+  "bounding_box": {
+    "min_x": 0,
+    "max_x": 15,
+    "min_y": 0,
+    "max_y": 15,
+    "min_z": 0,
+    "max_z": 50.0
+  },
+  "coordinate_reference_system": {
+    "epsg_code": 1024
+  },
+  "block_model_uuid": "00000000-0000-0000-0000-000000000002",
+  "block_model_version_uuid": "00000000-0000-0000-0000-000000000004",
+  "geometry": {
+    "model_type": "flexible",
+    "origin": [
+      0.0,
+      0.0,
+      0.0
+    ],
+    "n_parent_blocks": [
+      10,
+      10,
+      20
+    ],
+    "parent_block_size": [
+      1.5,
+      1.5,
+      2.5
+    ],
+    "n_subblocks_per_parent": [
+      15,
+      64,
+      21
+    ],
+    "rotation": {
+      "dip_azimuth": 90.0,
+      "dip": 45.0,
+      "pitch": 15.0
+    }
+  },
+  "attributes": [
+    {
+      "name": "example_attr",
+      "key": "00000000-0000-0000-0000-000000000004",
+      "block_model_column_uuid": "00000000-0000-0000-0000-000000000004",
+      "attribute_type": "Boolean"
+    }
+  ],
+  "tags": {},
+  "extensions": {}
+}

--- a/examples/1.2.0/objects/block-model-3.json
+++ b/examples/1.2.0/objects/block-model-3.json
@@ -1,0 +1,57 @@
+{
+  "schema": "/objects/block-model/1.2.0/block-model.schema.json",
+  "name": "Example Block Model",
+  "uuid": "00000000-0000-0000-0000-000000000002",
+  "description": "This is example data to ensure the object validates properly.",
+  "bounding_box": {
+    "min_x": 0,
+    "max_x": 15,
+    "min_y": 0,
+    "max_y": 15,
+    "min_z": 0,
+    "max_z": 50.0
+  },
+  "coordinate_reference_system": {
+    "epsg_code": 1024
+  },
+  "block_model_uuid": "00000000-0000-0000-0000-000000000003",
+  "block_model_version_uuid": "00000000-0000-0000-0000-000000000008",
+  "geometry": {
+    "model_type": "fully-sub-blocked",
+    "origin": [
+      0.0,
+      0.0,
+      0.0
+    ],
+    "n_parent_blocks": [
+      10,
+      10,
+      20
+    ],
+    "parent_block_size": [
+      1.5,
+      1.5,
+      2.5
+    ],
+    "n_subblocks_per_parent": [
+      8,
+      20,
+      15
+    ],
+    "rotation": {
+      "dip_azimuth": 270.0,
+      "dip": 5.0,
+      "pitch": 150.0
+    }
+  },
+  "attributes": [
+    {
+      "name": "example_attr",
+      "key": "00000000-0000-0000-0000-000000000016",
+      "block_model_column_uuid": "00000000-0000-0000-0000-000000000016",
+      "attribute_type": "Utf8"
+    }
+  ],
+  "tags": {},
+  "extensions": {}
+}

--- a/examples/1.2.0/objects/block-model-4.json
+++ b/examples/1.2.0/objects/block-model-4.json
@@ -1,0 +1,57 @@
+{
+  "schema": "/objects/block-model/1.2.0/block-model.schema.json",
+  "name": "Example Block Model",
+  "uuid": "00000000-0000-0000-0000-000000000003",
+  "description": "This is example data to ensure the object validates properly.",
+  "bounding_box": {
+    "min_x": 0,
+    "max_x": 15,
+    "min_y": 0,
+    "max_y": 15,
+    "min_z": 0,
+    "max_z": 50.0
+  },
+  "coordinate_reference_system": {
+    "epsg_code": 1024
+  },
+  "block_model_uuid": "00000000-0000-0000-0000-000000000004",
+  "block_model_version_uuid": "00000000-0000-0000-0000-000000000016",
+  "geometry": {
+    "model_type": "variable-octree",
+    "origin": [
+      0.0,
+      0.0,
+      0.0
+    ],
+    "n_parent_blocks": [
+      10,
+      10,
+      20
+    ],
+    "parent_block_size": [
+      1.5,
+      1.5,
+      2.5
+    ],
+    "n_subblocks_per_parent": [
+      8,
+      16,
+      4
+    ],
+    "rotation": {
+      "dip_azimuth": 70.0,
+      "dip": 50.0,
+      "pitch": 1.0
+    }
+  },
+  "attributes": [
+    {
+      "name": "example_attr",
+      "key": "00000000-0000-0000-0000-000000000032",
+      "block_model_column_uuid": "00000000-0000-0000-0000-000000000032",
+      "attribute_type": "Date32"
+    }
+  ],
+  "tags": {},
+  "extensions": {}
+}

--- a/schema/components/block-model-attribute/1.2.0/block-model-attribute.schema.json
+++ b/schema/components/block-model-attribute/1.2.0/block-model-attribute.schema.json
@@ -1,0 +1,44 @@
+{
+  "$id": "/components/block-model-attribute/1.2.0/block-model-attribute.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "A block model attribute stored by the Block Model Service. Covers both continuous and categorical attributes.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "/components/base-continuous-attribute/1.1.0/base-continuous-attribute.schema.json"
+    },
+    {
+      "properties": {
+        "attribute_type": {
+          "description": "The data type of the attribute as stored in the Block Model Service.",
+          "enum": [
+            "Boolean",
+            "Utf8",
+            "Int8",
+            "Int16",
+            "Int32",
+            "Int64",
+            "UInt8",
+            "UInt16",
+            "UInt32",
+            "UInt64",
+            "Float16",
+            "Float32",
+            "Float64",
+            "Date32",
+            "Timestamp"
+          ]
+        },
+        "block_model_column_uuid": {
+          "description": "The unique ID of the attribute on the block model.",
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    }
+  ],
+  "required": [
+    "attribute_type",
+    "block_model_column_uuid"
+  ]
+}

--- a/schema/geoscience-objects.schema.json
+++ b/schema/geoscience-objects.schema.json
@@ -11,6 +11,9 @@
       "$ref": "/objects/block-model/1.1.0/block-model.schema.json"
     },
     {
+      "$ref": "/objects/block-model/1.2.0/block-model.schema.json"
+    },
+    {
       "$ref": "/objects/design-geometry/1.0.1/design-geometry.schema.json"
     },
     {

--- a/schema/objects/block-model/1.2.0/block-model.schema.json
+++ b/schema/objects/block-model/1.2.0/block-model.schema.json
@@ -1,0 +1,58 @@
+{
+  "$id": "/objects/block-model/1.2.0/block-model.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "A reference to a block model stored in the Block Model Service.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "/components/base-spatial-data-properties/1.1.0/base-spatial-data-properties.schema.json"
+    },
+    {
+      "properties": {
+        "schema": {
+          "const": "/objects/block-model/1.2.0/block-model.schema.json"
+        },
+        "block_model_uuid": {
+          "description": "The unique ID of the block model in the Block Model Service.",
+          "type": "string",
+          "format": "uuid"
+        },
+        "block_model_version_uuid": {
+          "description": "The unique ID of this version of the block model in the Block Model Service.",
+          "type": "string",
+          "format": "uuid"
+        },
+        "geometry": {
+          "description": "The geometry (including subblocking parameters, if applicable) of the block model.",
+          "oneOf": [
+            {
+              "$ref": "/components/block-model-flexible-structure/1.0.0/block-model-flexible-structure.schema.json"
+            },
+            {
+              "$ref": "/components/block-model-fully-subblocked-structure/1.0.0/block-model-fully-subblocked-structure.schema.json"
+            },
+            {
+              "$ref": "/components/block-model-regular-structure/1.0.0/block-model-regular-structure.schema.json"
+            },
+            {
+              "$ref": "/components/block-model-variable-octree-structure/1.0.0/block-model-variable-octree-structure.schema.json"
+            }
+          ]
+        },
+        "attributes": {
+          "description": "The attributes found on this version of the block model.",
+          "type": "array",
+          "items": {
+            "$ref": "/components/block-model-attribute/1.2.0/block-model-attribute.schema.json"
+          }
+        }
+      }
+    }
+  ],
+  "required": [
+    "schema",
+    "block_model_uuid",
+    "geometry"
+  ],
+  "unevaluatedProperties": false
+}


### PR DESCRIPTION
<!--
Thank you for taking the time to make a pull request.

Please review our [contribution guide](https://github.com/seequentevo/evo-schemas/blob/main/CONTRIBUTING.md) and our
[code of conduct](https://github.com/seequentevo/evo-schemas/blob/main/CONTRIBUTING.md) before opening your first
pull request.

By making a pull request, you confirm you agree to our Contributor License Agreement (CLA).
-->

## Description

**Changes:**
- Merged enum in bmattr/1.2.0 (added Boolean, Utf8; description updated).
- Collapsed block-model/1.2.0 attributes.items oneOf -> single $ref bmattr/1.2.0.
- Examples copied to examples/1.2.0 (component + block-model-1..4);
- docs/schemas/components/block-model-attribute.md bumped to 1.2.0 + consolidation note.
- Root schema regenerated (adds block-model/1.2.0).

**Validation:**
- Full suite 4360 passed, 0 failed, 149 (pre-existing unit) warnings.
- Proved mixed [Int32, Utf8, Boolean, Float32] attribute array validates against
  block-model/1.2.0 with the single merged type (no ambiguity).
- pre-commit (json/format/root schema) clean.

## Checklist

- [x] I have read the contributing guide and the code of conduct
