### PR TITLE
Add secondary approver

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 * @seequentevo/evo-schemas-maintainers
-* @bsmithyman
+* @bsmithyman @ryanpainter


### PR DESCRIPTION
Add @ryanpainter as a secondary / alternate approver for backup when @bsmithyman is unavailable.

I'm totally pleased for Ryan to have this authority – he's been working on this longer than me, and we'll coordinate between us to make sure we're on the same page. This has already been through the 👍🏻 channels internally.

## Intended behaviour

This should allow _either_ of us to approve merges.

## Checklist

- [x] I have read the contributing guide and the code of conduct
