### PR TITLE
blockmodel-1.3.0 - add support for attribute groups (i.e. column groups) .

### DIFF
--- a/docs/schemas/components/block-model-attribute-group.md
+++ b/docs/schemas/components/block-model-attribute-group.md
@@ -1,0 +1,21 @@
+import SchemaUri from '@theme/SchemaUri';
+import FlatProperties from '../generated/flatmd/components/block-model-attribute-group-1.0.0.md';
+
+# block-model-attribute-group
+
+<SchemaUri uri="schema/components/block-model-attribute-group/1.0.0/block-model-attribute-group.schema.json" />
+
+A block-model attribute group defines metadata for a logical grouping of block-model attributes. Groups can form a hierarchy using `parent_group_uuid`; attributes join a group through their `block_model_group_uuid`. Groups lacking a `parent_group_id` are treated implicitely as the "root groups". 
+
+
+**See also:** [block-model-attribute](block-model-attribute.md) (block-model attribute metadata).
+
+## Constraints
+
+The Block Model API enforces additional constraints which aren't represented in the schema. The key constraints are:
+* Each groups `parent_group_uuid` and each attribute's `block_model_group_uuid` must reference a declared group.
+* Parent group references must not form a cycle.
+
+## Properties
+
+<FlatProperties />

--- a/docs/schemas/components/block-model-attribute-group.md
+++ b/docs/schemas/components/block-model-attribute-group.md
@@ -5,7 +5,7 @@ import FlatProperties from '../generated/flatmd/components/block-model-attribute
 
 <SchemaUri uri="schema/components/block-model-attribute-group/1.0.0/block-model-attribute-group.schema.json" />
 
-A block-model attribute group defines metadata for a logical grouping of block-model attributes. Groups can form a hierarchy using `parent_group_uuid`; attributes join a group through their `block_model_group_uuid`. Groups lacking a `parent_group_id` are treated implicitely as the "root groups". 
+A block-model-attribute-group defines metadata for a logical column group in a block model. Groups can form a hierarchy using `parent_group_uuid`; attributes join a group through their `block_model_group_uuid`. Groups without a `parent_group_uuid` are root groups.
 
 
 **See also:** [block-model-attribute](block-model-attribute.md) (block-model attribute metadata).

--- a/docs/schemas/components/block-model-attribute-group.md
+++ b/docs/schemas/components/block-model-attribute-group.md
@@ -5,16 +5,30 @@ import FlatProperties from '../generated/flatmd/components/block-model-attribute
 
 <SchemaUri uri="schema/components/block-model-attribute-group/1.0.0/block-model-attribute-group.schema.json" />
 
-A block-model-attribute-group defines metadata for a logical column group in a block model. Groups can form a hierarchy using `parent_group_uuid`; attributes join a group through their `block_model_group_uuid`. Groups without a `parent_group_uuid` are root groups.
+A block-model attribute group defines metadata for a logical grouping of block-model attributes. Groups can
+form a hierarchy using `parent_group_uuid`; attributes join a group through their `block_model_group_uuid`.
+A group whose `parent_group_uuid` is null or absent is a top-level group.
 
+Groups are declared on the block-model object in its `groups` array. Membership is not recorded in the group
+itself -- it is expressed by the pointer held on each attribute -- so a group can be declared before any
+attribute references it.
 
-**See also:** [block-model-attribute](block-model-attribute.md) (block-model attribute metadata).
+The Block Model Service stores attribute values column-wise, so its API refers to an attribute as a *column*.
+The two terms denote the same thing: `missing_column_policy` governs the attributes that are members of the
+group, and `block_model_column_uuid` on [block-model-attribute](block-model-attribute.md) identifies the
+column backing that attribute.
+
+**Used by:** block-model.
+
+**See also:** [block-model-attribute](block-model-attribute.md) (the attributes that groups organise).
 
 ## Constraints
 
 The Block Model API enforces additional constraints which aren't represented in the schema. The key constraints are:
-* Each groups `parent_group_uuid` and each attribute's `block_model_group_uuid` must reference a declared group.
+
+* Each group's `parent_group_uuid`, and each attribute's `block_model_group_uuid`, must reference a declared group.
 * Parent group references must not form a cycle.
+* `title` must be unique among sibling groups sharing a parent, and among top-level groups.
 
 ## Properties
 

--- a/docs/schemas/components/block-model-attribute.md
+++ b/docs/schemas/components/block-model-attribute.md
@@ -1,9 +1,9 @@
 import SchemaUri from '@theme/SchemaUri';
-import FlatProperties from '../generated/flatmd/components/block-model-attribute-1.2.0.md';
+import FlatProperties from '../generated/flatmd/components/block-model-attribute-1.3.0.md';
 
 # block-model-attribute
 
-<SchemaUri uri="schema/components/block-model-attribute/1.2.0/block-model-attribute.schema.json" />
+<SchemaUri uri="schema/components/block-model-attribute/1.3.0/block-model-attribute.schema.json" />
 
 A block model attribute extends the standard attribute system for use with block model data. Block model
 attributes accommodate the variable-length sub-block structure of block models.
@@ -13,10 +13,16 @@ value storage. As of 1.2.0 it is the single attribute type used by the block-mod
 continuous and categorical attributes via its `attribute_type` (`Boolean` and `Utf8` alongside the numeric,
 date, and timestamp types).
 
+As of 1.3.0 an attribute may also declare membership of an attribute group through the optional
+`block_model_group_uuid`, which references the `group_uuid` of a
+[block-model-attribute-group](block-model-attribute-group.md) declared on the block-model object. An attribute
+without `block_model_group_uuid` is ungrouped.
+
 **Used by:** block-model.
 
-**See also:** [block-model-category-attribute](block-model-category-attribute.md) (separate categorical
-attribute used by block-model 1.1.0 and earlier).
+**See also:** [block-model-attribute-group](block-model-attribute-group.md) (grouping metadata for these
+attributes), [block-model-category-attribute](block-model-category-attribute.md) (separate categorical attribute
+used by block-model 1.1.0 and earlier).
 
 ## Properties
 

--- a/docs/schemas/generated/flatmd/components/block-model-attribute-1.3.0.md
+++ b/docs/schemas/generated/flatmd/components/block-model-attribute-1.3.0.md
@@ -1,0 +1,21 @@
+### block-model-attribute (v1.3.0)
+A block model attribute stored by the Block Model Service. Covers both continuous and categorical attributes.
+
+| Property | Type | Description | Flags |
+|---|---|---|---|
+| name | String | The name of the attribute | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
+| key | String | An identifier of the attribute, used to keep track of the attribute when it is renamed.<br/>The identifier must be unique within an attribute list. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
+| attribute_type | String | Type of the attribute. | [⬆️](../components/base-attribute-1.0.0.md) ✅ |
+| attribute_description | [attribute-description](../components/attribute-description-1.1.0.md) | The attribute description record. | [⬆️](../components/base-continuous-attribute-1.1.0.md) |
+| attribute_type | String | The data type of the attribute as stored in the Block Model Service. | ✅ |
+| block_model_column_uuid | String | The unique ID of the attribute on the block model. | ✅ |
+| block_model_group_uuid | String | The unique ID of the column group that that the attribute belongs to. |  |
+
+
+#### Legend
+
+| Flag | Description |
+| --- | --- |
+| ⬆️ | Inherited property |
+| ✅ | Required property |
+

--- a/docs/schemas/generated/flatmd/components/block-model-attribute-1.3.0.md
+++ b/docs/schemas/generated/flatmd/components/block-model-attribute-1.3.0.md
@@ -9,7 +9,7 @@ A block model attribute stored by the Block Model Service. Covers both continuou
 | attribute_description | [attribute-description](../components/attribute-description-1.1.0.md) | The attribute description record. | [⬆️](../components/base-continuous-attribute-1.1.0.md) |
 | attribute_type | String | The data type of the attribute as stored in the Block Model Service. | ✅ |
 | block_model_column_uuid | String | The unique ID of the attribute on the block model. | ✅ |
-| block_model_group_uuid | String | The unique ID of the column group that that the attribute belongs to. |  |
+| block_model_group_uuid | String | The unique ID of the attribute group (column group) that the attribute belongs to. |  |
 
 
 #### Legend

--- a/docs/schemas/generated/flatmd/components/block-model-attribute-group-1.0.0-parent_group_uuid-Option-0.md
+++ b/docs/schemas/generated/flatmd/components/block-model-attribute-group-1.0.0-parent_group_uuid-Option-0.md
@@ -1,0 +1,13 @@
+### block-model-attribute-group (v1.0.0)
+
+| Property | Type | Description | Flags |
+|---|---|---|---|
+
+
+#### Legend
+
+| Flag | Description |
+| --- | --- |
+| ⬆️ | Inherited property |
+| ✅ | Required property |
+

--- a/docs/schemas/generated/flatmd/components/block-model-attribute-group-1.0.0-parent_group_uuid-Option-1.md
+++ b/docs/schemas/generated/flatmd/components/block-model-attribute-group-1.0.0-parent_group_uuid-Option-1.md
@@ -1,0 +1,13 @@
+### block-model-attribute-group (v1.0.0)
+
+| Property | Type | Description | Flags |
+|---|---|---|---|
+
+
+#### Legend
+
+| Flag | Description |
+| --- | --- |
+| ⬆️ | Inherited property |
+| ✅ | Required property |
+

--- a/docs/schemas/generated/flatmd/components/block-model-attribute-group-1.0.0-parent_group_uuid.md
+++ b/docs/schemas/generated/flatmd/components/block-model-attribute-group-1.0.0-parent_group_uuid.md
@@ -1,0 +1,14 @@
+### block-model-attribute-group (v1.0.0)
+Identifier of the parent group. Null means the group is a 'top-level' group.
+
+| Property | Type | Description | Flags |
+|---|---|---|---|
+
+
+#### Legend
+
+| Flag | Description |
+| --- | --- |
+| ⬆️ | Inherited property |
+| ✅ | Required property |
+

--- a/docs/schemas/generated/flatmd/components/block-model-attribute-group-1.0.0.md
+++ b/docs/schemas/generated/flatmd/components/block-model-attribute-group-1.0.0.md
@@ -1,0 +1,20 @@
+### block-model-attribute-group (v1.0.0)
+Column group metadata
+
+| Property | Type | Description | Flags |
+|---|---|---|---|
+| group_uuid | String | Unique identifier for the group. |  |
+| is_hidden | Boolean | When true, the group's direct member columns are excluded from wildcard queries (unless include_hidden is set in the query). |  |
+| missing_column_policy | String | Defines the update behaviour, for all columns in the group, for columns that do not have a value provided. |  |
+| parent_group_uuid | [block-model-attribute-group](../components/block-model-attribute-group-1.0.0-parent_group_uuid.md) | Identifier of the parent group. Null means the group is a 'top-level' group. |  |
+| tags | Object | Publisher-supplied free-form metadata for the group, as a JSON object. Keys must be 1-100 chars and cannot contain leading whitespace or dot, or the characters `/ \ : > < \| ? " *`; keys are unique case-insensitively. Values may be any JSON-compatible type. A single `tags` object serialised as UTF-8 JSON must be at most 10 KiB. |  |
+| title | String | 'Human-readable label for the group, unique across the parent group, or across top-level groups if no parent. They must be 1-100 chars and cannot contain leading whitespace or dot, or the characters `/ \ : > < \| ? " *`. Must not contain the qualified title separator `▸`.' |  |
+
+
+#### Legend
+
+| Flag | Description |
+| --- | --- |
+| ⬆️ | Inherited property |
+| ✅ | Required property |
+

--- a/docs/schemas/generated/flatmd/components/block-model-attribute-group-1.0.0.md
+++ b/docs/schemas/generated/flatmd/components/block-model-attribute-group-1.0.0.md
@@ -1,5 +1,5 @@
 ### block-model-attribute-group (v1.0.0)
-Column group metadata
+Metadata for a named group of block model attributes (columns), optionally nested within a parent group.
 
 | Property | Type | Description | Flags |
 |---|---|---|---|
@@ -8,7 +8,7 @@ Column group metadata
 | missing_column_policy | String | Defines the update behaviour, for all columns in the group, for columns that do not have a value provided. |  |
 | parent_group_uuid | [block-model-attribute-group](../components/block-model-attribute-group-1.0.0-parent_group_uuid.md) | Identifier of the parent group. Null means the group is a 'top-level' group. |  |
 | tags | Object | Publisher-supplied free-form metadata for the group, as a JSON object. Keys must be 1-100 chars and cannot contain leading whitespace or dot, or the characters `/ \ : > < \| ? " *`; keys are unique case-insensitively. Values may be any JSON-compatible type. A single `tags` object serialised as UTF-8 JSON must be at most 10 KiB. |  |
-| title | String | 'Human-readable label for the group, unique across the parent group, or across top-level groups if no parent. They must be 1-100 chars and cannot contain leading whitespace or dot, or the characters `/ \ : > < \| ? " *`. Must not contain the qualified title separator `▸`.' |  |
+| title | String | Human-readable label for the group, unique across the parent group, or across top-level groups if no parent. Titles must be 1-100 characters and cannot contain leading whitespace or dot, or the characters `/ \ : > < \| ? " *`. Must not contain the qualified title separator `▸`. |  |
 
 
 #### Legend

--- a/docs/schemas/generated/flatmd/components/block-model-attribute-group-1.0.0.md
+++ b/docs/schemas/generated/flatmd/components/block-model-attribute-group-1.0.0.md
@@ -3,7 +3,7 @@ Metadata for a named group of block model attributes (columns), optionally neste
 
 | Property | Type | Description | Flags |
 |---|---|---|---|
-| group_uuid | String | Unique identifier for the group. |  |
+| group_uuid | String | Unique identifier for the group. | ✅ |
 | is_hidden | Boolean | When true, the group's direct member columns are excluded from wildcard queries (unless include_hidden is set in the query). |  |
 | missing_column_policy | String | Defines the update behaviour, for all columns in the group, for columns that do not have a value provided. |  |
 | parent_group_uuid | [block-model-attribute-group](../components/block-model-attribute-group-1.0.0-parent_group_uuid.md) | Identifier of the parent group. Null means the group is a 'top-level' group. |  |

--- a/docs/schemas/generated/flatmd/components/block-model-attribute-group-1.0.0.md
+++ b/docs/schemas/generated/flatmd/components/block-model-attribute-group-1.0.0.md
@@ -4,10 +4,10 @@ Metadata for a named group of block model attributes (columns), optionally neste
 | Property | Type | Description | Flags |
 |---|---|---|---|
 | group_uuid | String | Unique identifier for the group. | ✅ |
-| is_hidden | Boolean | When true, the group's direct member columns are excluded from wildcard queries (unless include_hidden is set in the query). |  |
-| missing_column_policy | String | Defines the update behaviour, for all columns in the group, for columns that do not have a value provided. |  |
+| is_hidden | Boolean | When true, indicates that the Block Model Service will exclude group members from wildcard queries by default. |  |
+| missing_column_policy | String | Defines the update behaviour for all columns in the group that do not have a value provided. |  |
 | parent_group_uuid | [block-model-attribute-group](../components/block-model-attribute-group-1.0.0-parent_group_uuid.md) | Identifier of the parent group. Null means the group is a 'top-level' group. |  |
-| tags | Object | Publisher-supplied free-form metadata for the group, as a JSON object. Keys must be 1-100 chars and cannot contain leading whitespace or dot, or the characters `/ \ : > < \| ? " *`; keys are unique case-insensitively. Values may be any JSON-compatible type. A single `tags` object serialised as UTF-8 JSON must be at most 10 KiB. |  |
+| tags | Object | Publisher-supplied free-form metadata for the group, as a JSON object. Keys must be 1-100 characters and cannot contain leading whitespace or dot, or the characters `/ \ : > < \| ? " *`; keys are unique case-insensitively. Values may be any JSON-compatible type. A single `tags` object serialised as UTF-8 JSON must be at most 10 KiB. |  |
 | title | String | Human-readable label for the group, unique across the parent group, or across top-level groups if no parent. Titles must be 1-100 characters and cannot contain leading whitespace or dot, or the characters `/ \ : > < \| ? " *`. Must not contain the qualified title separator `▸`. | ✅ |
 
 

--- a/docs/schemas/generated/flatmd/components/block-model-attribute-group-1.0.0.md
+++ b/docs/schemas/generated/flatmd/components/block-model-attribute-group-1.0.0.md
@@ -8,7 +8,7 @@ Metadata for a named group of block model attributes (columns), optionally neste
 | missing_column_policy | String | Defines the update behaviour, for all columns in the group, for columns that do not have a value provided. |  |
 | parent_group_uuid | [block-model-attribute-group](../components/block-model-attribute-group-1.0.0-parent_group_uuid.md) | Identifier of the parent group. Null means the group is a 'top-level' group. |  |
 | tags | Object | Publisher-supplied free-form metadata for the group, as a JSON object. Keys must be 1-100 chars and cannot contain leading whitespace or dot, or the characters `/ \ : > < \| ? " *`; keys are unique case-insensitively. Values may be any JSON-compatible type. A single `tags` object serialised as UTF-8 JSON must be at most 10 KiB. |  |
-| title | String | Human-readable label for the group, unique across the parent group, or across top-level groups if no parent. Titles must be 1-100 characters and cannot contain leading whitespace or dot, or the characters `/ \ : > < \| ? " *`. Must not contain the qualified title separator `▸`. |  |
+| title | String | Human-readable label for the group, unique across the parent group, or across top-level groups if no parent. Titles must be 1-100 characters and cannot contain leading whitespace or dot, or the characters `/ \ : > < \| ? " *`. Must not contain the qualified title separator `▸`. | ✅ |
 
 
 #### Legend

--- a/docs/schemas/generated/flatmd/objects/block-model-1.3.0-geometry.md
+++ b/docs/schemas/generated/flatmd/objects/block-model-1.3.0-geometry.md
@@ -1,0 +1,14 @@
+### block-model (v1.3.0)
+The geometry (including subblocking parameters, if applicable) of the block model.
+
+| Property | Type | Description | Flags |
+|---|---|---|---|
+
+
+#### Legend
+
+| Flag | Description |
+| --- | --- |
+| ⬆️ | Inherited property |
+| ✅ | Required property |
+

--- a/docs/schemas/generated/flatmd/objects/block-model-1.3.0.md
+++ b/docs/schemas/generated/flatmd/objects/block-model-1.3.0.md
@@ -1,0 +1,28 @@
+### block-model (v1.3.0)
+A reference to a block model stored in the Block Model Service.
+
+| Property | Type | Description | Flags |
+|---|---|---|---|
+| name | String | Name of the object. | [⬆️](../components/base-object-properties-1.1.0.md) ✅ |
+| uuid | [base-object-properties](../components/base-object-properties-1.1.0-uuid.md) | Identifier of the object. | [⬆️](../components/base-object-properties-1.1.0.md) ✅ |
+| description | String | Optional field for adding additional description to uniquely identify this object. | [⬆️](../components/base-object-properties-1.1.0.md) |
+| extensions | Object | Extended properties that may be associated to the object, but not specified in the schema | [⬆️](../components/base-object-properties-1.1.0.md) |
+| tags | Object | Key-value pairs of user-defined metadata | [⬆️](../components/base-object-properties-1.1.0.md) |
+| lineage | [lineage](../components/lineage-1.0.0.md) | Information about the history of the object | [⬆️](../components/base-object-properties-1.1.0.md) |
+| bounding_box | [bounding-box](../components/bounding-box-1.0.1.md) | Bounding box of the spatial data. | [⬆️](../components/base-spatial-data-properties-1.1.0.md) ✅ |
+| coordinate_reference_system | [crs](../components/crs-1.0.1.md) | Coordinate system of the spatial data | [⬆️](../components/base-spatial-data-properties-1.1.0.md) ✅ |
+| schema | String |  | ✅ |
+| block_model_uuid | String | The unique ID of the block model in the Block Model Service. | ✅ |
+| block_model_version_uuid | String | The unique ID of this version of the block model in the Block Model Service. |  |
+| geometry | [block-model](../objects/block-model-1.3.0-geometry.md) | The geometry (including subblocking parameters, if applicable) of the block model. | ✅ |
+| attributes | Array[[block-model-attribute](../components/block-model-attribute-1.3.0.md)] | The attributes found on this version of the block model. |  |
+| groups | Array[[block-model-attribute-group](../components/block-model-attribute-group-1.0.0.md)] | The attribute groups available on this blockmodel. Note that group memberships are not included in this data; group memberships are set by a uuid pointer in `attributes`. |  |
+
+
+#### Legend
+
+| Flag | Description |
+| --- | --- |
+| ⬆️ | Inherited property |
+| ✅ | Required property |
+

--- a/docs/schemas/generated/flatmd/objects/block-model-1.3.0.md
+++ b/docs/schemas/generated/flatmd/objects/block-model-1.3.0.md
@@ -16,7 +16,7 @@ A reference to a block model stored in the Block Model Service.
 | block_model_version_uuid | String | The unique ID of this version of the block model in the Block Model Service. |  |
 | geometry | [block-model](../objects/block-model-1.3.0-geometry.md) | The geometry (including subblocking parameters, if applicable) of the block model. | ✅ |
 | attributes | Array[[block-model-attribute](../components/block-model-attribute-1.3.0.md)] | The attributes found on this version of the block model. |  |
-| groups | Array[[block-model-attribute-group](../components/block-model-attribute-group-1.0.0.md)] | The attribute groups available on this blockmodel. Note that group memberships are not included in this data; group memberships are set by a uuid pointer in `attributes`. |  |
+| groups | Array[[block-model-attribute-group](../components/block-model-attribute-group-1.0.0.md)] | The block-model-attribute-groups available on this block model. Attribute membership is set by the `block_model_group_uuid` property. |  |
 
 
 #### Legend

--- a/docs/schemas/generated/uml/block-model-1.3.0.mmd
+++ b/docs/schemas/generated/uml/block-model-1.3.0.mmd
@@ -1,0 +1,65 @@
+---
+config:
+    class:
+        hideEmptyMembersBox: true
+---
+
+classDiagram
+    class `components/base-object-properties-1.1.0`:::schemaComponent {
+        name: string
+        uuid: components/base-object-properties-1.1.0-uuid
+        description: string
+        extensions: object
+        tags: object
+        lineage: components/lineage-1.0.0
+    }
+    class `components/base-spatial-data-properties-1.1.0`:::schemaComponent {
+        name: string*
+        uuid: components/base-object-properties-1.1.0-uuid*
+        description: string*
+        extensions: object*
+        tags: object*
+        lineage: components/lineage-1.0.0*
+        bounding_box: components/bounding-box-1.0.1
+        coordinate_reference_system: components/crs-1.0.1
+    }
+    `components/base-object-properties-1.1.0` <|-- `components/base-spatial-data-properties-1.1.0`
+    class `objects/block-model-1.3.0`:::schemaObject {
+        name: string*
+        uuid: components/base-object-properties-1.1.0-uuid*
+        description: string*
+        extensions: object*
+        tags: object*
+        lineage: components/lineage-1.0.0*
+        bounding_box: components/bounding-box-1.0.1*
+        coordinate_reference_system: components/crs-1.0.1*
+        block_model_uuid: string
+        block_model_version_uuid: string
+        geometry: objects/block-model-1.3.0-geometry
+        attributes: array
+        groups: array
+    }
+    `components/base-spatial-data-properties-1.1.0` <|-- `objects/block-model-1.3.0`
+    `components/base-object-properties-1.1.0` *-- `components/base-object-properties-1.1.0-uuid` : ref uuid*
+    `components/base-object-properties-1.1.0` *-- `components/lineage-1.0.0` : ref lineage*
+    `components/base-spatial-data-properties-1.1.0` *-- `components/bounding-box-1.0.1` : ref bounding_box*
+    `components/base-spatial-data-properties-1.1.0` *-- `components/crs-1.0.1` : ref coordinate_reference_system*
+    `objects/block-model-1.3.0` *-- `objects/block-model-1.3.0-geometry` : ref geometry*
+    class `components/base-object-properties-1.1.0-uuid`:::schemaImplicit {
+    }
+    class `components/lineage-1.0.0`:::schemaComponent {
+        self_link: string
+        events: array
+    }
+    class `components/bounding-box-1.0.1`:::schemaComponent {
+        min_x: number
+        max_x: number
+        min_y: number
+        max_y: number
+        min_z: number
+        max_z: number
+    }
+    class `components/crs-1.0.1`:::schemaComponent {
+    }
+    class `objects/block-model-1.3.0-geometry`:::schemaImplicit {
+    }

--- a/examples/1.0.0/components/block-model-attribute-group.json
+++ b/examples/1.0.0/components/block-model-attribute-group.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "/components/block-model-attribute-group/1.0.0/block-model-attribute-group.schema.json",
+  "group_uuid": "f2a7c18d-95e4-4b63-8d20-7c1e4a9f6b35",
+  "title": "Resource estimation",
+  "missing_column_policy": "use_previous",
+  "tags": {
+    "domain": "resource-modeling",
+    "owner": "geology"
+  }
+}

--- a/examples/1.3.0/components/block-model-attribute.json
+++ b/examples/1.3.0/components/block-model-attribute.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "/components/block-model-attribute/1.3.0/block-model-attribute.schema.json",
+  "name": "AU",
+  "key": "f1b1a3b0-1b9b-4b6c-9b6b-3b4f1d2b0b0b",
+  "attribute_type": "Float32",
+  "block_model_column_uuid": "f1b1a3b0-1b9b-4b6c-9b6b-3b4f1d2b0b0b",
+  "attribute_description": {
+    "discipline": "Geochemistry",
+    "type": "Gold",
+    "unit": "%"
+  }
+}

--- a/examples/1.3.0/objects/block-model-1.json
+++ b/examples/1.3.0/objects/block-model-1.json
@@ -1,0 +1,57 @@
+{
+  "schema": "/objects/block-model/1.3.0/block-model.schema.json",
+  "name": "Example Block Model",
+  "uuid": "00000000-0000-0000-0000-000000000000",
+  "description": "This is example data to ensure the object validates properly.",
+  "bounding_box": {
+    "min_x": 0,
+    "max_x": 15,
+    "min_y": 0,
+    "max_y": 15,
+    "min_z": 0,
+    "max_z": 50.0
+  },
+  "coordinate_reference_system": {
+    "epsg_code": 1024
+  },
+  "block_model_uuid": "00000000-0000-0000-0000-000000000001",
+  "block_model_version_uuid": "00000000-0000-0000-0000-000000000002",
+  "geometry": {
+    "model_type": "regular",
+    "origin": [
+      0.0,
+      0.0,
+      0.0
+    ],
+    "n_blocks": [
+      10,
+      10,
+      20
+    ],
+    "block_size": [
+      1.5,
+      1.5,
+      2.5
+    ],
+    "rotation": {
+      "dip_azimuth": 0.0,
+      "dip": 0.0,
+      "pitch": 0.0
+    }
+  },
+  "attributes": [
+    {
+      "name": "AU",
+      "key": "00000000-0000-0000-0000-000000000003",
+      "block_model_column_uuid": "00000000-0000-0000-0000-000000000003",
+      "attribute_type": "Float16",
+      "attribute_description": {
+        "discipline": "Geochemistry",
+        "type": "Gold",
+        "unit": "%"
+      }
+    }
+  ],
+  "tags": {},
+  "extensions": {}
+}

--- a/examples/1.3.0/objects/block-model-2.json
+++ b/examples/1.3.0/objects/block-model-2.json
@@ -1,0 +1,57 @@
+{
+  "schema": "/objects/block-model/1.3.0/block-model.schema.json",
+  "name": "Example Block Model",
+  "uuid": "00000000-0000-0000-0000-000000000001",
+  "description": "This is example data to ensure the object validates properly.",
+  "bounding_box": {
+    "min_x": 0,
+    "max_x": 15,
+    "min_y": 0,
+    "max_y": 15,
+    "min_z": 0,
+    "max_z": 50.0
+  },
+  "coordinate_reference_system": {
+    "epsg_code": 1024
+  },
+  "block_model_uuid": "00000000-0000-0000-0000-000000000002",
+  "block_model_version_uuid": "00000000-0000-0000-0000-000000000004",
+  "geometry": {
+    "model_type": "flexible",
+    "origin": [
+      0.0,
+      0.0,
+      0.0
+    ],
+    "n_parent_blocks": [
+      10,
+      10,
+      20
+    ],
+    "parent_block_size": [
+      1.5,
+      1.5,
+      2.5
+    ],
+    "n_subblocks_per_parent": [
+      15,
+      64,
+      21
+    ],
+    "rotation": {
+      "dip_azimuth": 90.0,
+      "dip": 45.0,
+      "pitch": 15.0
+    }
+  },
+  "attributes": [
+    {
+      "name": "example_attr",
+      "key": "00000000-0000-0000-0000-000000000004",
+      "block_model_column_uuid": "00000000-0000-0000-0000-000000000004",
+      "attribute_type": "Boolean"
+    }
+  ],
+  "tags": {},
+  "extensions": {}
+}

--- a/examples/1.3.0/objects/block-model-3.json
+++ b/examples/1.3.0/objects/block-model-3.json
@@ -1,0 +1,57 @@
+{
+  "schema": "/objects/block-model/1.3.0/block-model.schema.json",
+  "name": "Example Block Model",
+  "uuid": "00000000-0000-0000-0000-000000000002",
+  "description": "This is example data to ensure the object validates properly.",
+  "bounding_box": {
+    "min_x": 0,
+    "max_x": 15,
+    "min_y": 0,
+    "max_y": 15,
+    "min_z": 0,
+    "max_z": 50.0
+  },
+  "coordinate_reference_system": {
+    "epsg_code": 1024
+  },
+  "block_model_uuid": "00000000-0000-0000-0000-000000000003",
+  "block_model_version_uuid": "00000000-0000-0000-0000-000000000008",
+  "geometry": {
+    "model_type": "fully-sub-blocked",
+    "origin": [
+      0.0,
+      0.0,
+      0.0
+    ],
+    "n_parent_blocks": [
+      10,
+      10,
+      20
+    ],
+    "parent_block_size": [
+      1.5,
+      1.5,
+      2.5
+    ],
+    "n_subblocks_per_parent": [
+      8,
+      20,
+      15
+    ],
+    "rotation": {
+      "dip_azimuth": 270.0,
+      "dip": 5.0,
+      "pitch": 150.0
+    }
+  },
+  "attributes": [
+    {
+      "name": "example_attr",
+      "key": "00000000-0000-0000-0000-000000000016",
+      "block_model_column_uuid": "00000000-0000-0000-0000-000000000016",
+      "attribute_type": "Utf8"
+    }
+  ],
+  "tags": {},
+  "extensions": {}
+}

--- a/examples/1.3.0/objects/block-model-4.json
+++ b/examples/1.3.0/objects/block-model-4.json
@@ -1,0 +1,57 @@
+{
+  "schema": "/objects/block-model/1.3.0/block-model.schema.json",
+  "name": "Example Block Model",
+  "uuid": "00000000-0000-0000-0000-000000000003",
+  "description": "This is example data to ensure the object validates properly.",
+  "bounding_box": {
+    "min_x": 0,
+    "max_x": 15,
+    "min_y": 0,
+    "max_y": 15,
+    "min_z": 0,
+    "max_z": 50.0
+  },
+  "coordinate_reference_system": {
+    "epsg_code": 1024
+  },
+  "block_model_uuid": "00000000-0000-0000-0000-000000000004",
+  "block_model_version_uuid": "00000000-0000-0000-0000-000000000016",
+  "geometry": {
+    "model_type": "variable-octree",
+    "origin": [
+      0.0,
+      0.0,
+      0.0
+    ],
+    "n_parent_blocks": [
+      10,
+      10,
+      20
+    ],
+    "parent_block_size": [
+      1.5,
+      1.5,
+      2.5
+    ],
+    "n_subblocks_per_parent": [
+      8,
+      16,
+      4
+    ],
+    "rotation": {
+      "dip_azimuth": 70.0,
+      "dip": 50.0,
+      "pitch": 1.0
+    }
+  },
+  "attributes": [
+    {
+      "name": "example_attr",
+      "key": "00000000-0000-0000-0000-000000000032",
+      "block_model_column_uuid": "00000000-0000-0000-0000-000000000032",
+      "attribute_type": "Date32"
+    }
+  ],
+  "tags": {},
+  "extensions": {}
+}

--- a/examples/1.3.0/objects/block-model-5.json
+++ b/examples/1.3.0/objects/block-model-5.json
@@ -2,7 +2,7 @@
   "schema": "/objects/block-model/1.3.0/block-model.schema.json",
   "name": "Gold Grade Estimation Block Model",
   "uuid": "6e15c8d1-4a2f-4b9e-8f73-1a9c5d2e7b40",
-  "description": "Example block model with nested attribute groups for gold grade estimation.",
+  "description": "Example block model with nested block-model-attribute-groups for gold grade estimation.",
   "bounding_box": {
     "min_x": 0,
     "max_x": 15,

--- a/examples/1.3.0/objects/block-model-5.json
+++ b/examples/1.3.0/objects/block-model-5.json
@@ -51,25 +51,25 @@
       "group_uuid": "4d9e1b72-a6c3-4f80-95d2-8b6a3e7c1f49",
       "parent_group_uuid": "f2a7c18d-95e4-4b63-8d20-7c1e4a9f6b35",
       "title": "Statistical evaluation",
-      "missing_column_policy": "INHERIT"
+      "missing_column_policy": "inherit"
     },
     {
       "group_uuid": "b5f0a3c8-2e71-4d96-8b4f-1c7a9e3d6f20",
       "parent_group_uuid": "4d9e1b72-a6c3-4f80-95d2-8b6a3e7c1f49",
       "title": "Ordinary kriging",
-      "missing_column_policy": "USE_PREVIOUS"
+      "missing_column_policy": "use_previous"
     },
     {
       "group_uuid": "8c3e7a1f-d952-4b60-9e18-4f6a2c8d1b75",
       "parent_group_uuid": "b5f0a3c8-2e71-4d96-8b4f-1c7a9e3d6f20",
       "title": "High-confidence estimate",
-      "missing_column_policy": "SET_NULL"
+      "missing_column_policy": "set_null"
     },
     {
       "group_uuid": "1b6d9f42-7e30-4c85-a1f6-9d3b2e8c5a74",
       "parent_group_uuid": "f2a7c18d-95e4-4b63-8d20-7c1e4a9f6b35",
       "title": "Constrained scenario",
-      "missing_column_policy": "REJECT",
+      "missing_column_policy": "reject",
       "is_hidden": true
     }
   ],

--- a/examples/1.3.0/objects/block-model-5.json
+++ b/examples/1.3.0/objects/block-model-5.json
@@ -1,0 +1,320 @@
+{
+  "schema": "/objects/block-model/1.3.0/block-model.schema.json",
+  "name": "Gold Grade Estimation Block Model",
+  "uuid": "6e15c8d1-4a2f-4b9e-8f73-1a9c5d2e7b40",
+  "description": "Example block model with nested attribute groups for gold grade estimation.",
+  "bounding_box": {
+    "min_x": 0,
+    "max_x": 15,
+    "min_y": 0,
+    "max_y": 15,
+    "min_z": 0,
+    "max_z": 50.0
+  },
+  "coordinate_reference_system": {
+    "epsg_code": 1024
+  },
+  "block_model_uuid": "a38f2d6b-7c1e-4f95-b049-5d8a3e6c2f17",
+  "block_model_version_uuid": "c7b4e1a9-83d6-4c2f-9e51-6a0d8b3f4c29",
+  "geometry": {
+    "model_type": "regular",
+    "origin": [
+      0.0,
+      0.0,
+      0.0
+    ],
+    "n_blocks": [
+      10,
+      10,
+      20
+    ],
+    "block_size": [
+      1.5,
+      1.5,
+      2.5
+    ],
+    "rotation": {
+      "dip_azimuth": 0.0,
+      "dip": 0.0,
+      "pitch": 0.0
+    }
+  },
+  "groups": [
+    {
+      "group_uuid": "f2a7c18d-95e4-4b63-8d20-7c1e4a9f6b35",
+      "title": "Au",
+      "tags": {
+        "commodity": "gold"
+      }
+    },
+    {
+      "group_uuid": "4d9e1b72-a6c3-4f80-95d2-8b6a3e7c1f49",
+      "parent_group_uuid": "f2a7c18d-95e4-4b63-8d20-7c1e4a9f6b35",
+      "title": "Statistical evaluation",
+      "missing_column_policy": "INHERIT"
+    },
+    {
+      "group_uuid": "b5f0a3c8-2e71-4d96-8b4f-1c7a9e3d6f20",
+      "parent_group_uuid": "4d9e1b72-a6c3-4f80-95d2-8b6a3e7c1f49",
+      "title": "Ordinary kriging",
+      "missing_column_policy": "USE_PREVIOUS"
+    },
+    {
+      "group_uuid": "8c3e7a1f-d952-4b60-9e18-4f6a2c8d1b75",
+      "parent_group_uuid": "b5f0a3c8-2e71-4d96-8b4f-1c7a9e3d6f20",
+      "title": "High-confidence estimate",
+      "missing_column_policy": "SET_NULL"
+    },
+    {
+      "group_uuid": "1b6d9f42-7e30-4c85-a1f6-9d3b2e8c5a74",
+      "parent_group_uuid": "f2a7c18d-95e4-4b63-8d20-7c1e4a9f6b35",
+      "title": "Constrained scenario",
+      "missing_column_policy": "REJECT",
+      "is_hidden": true
+    }
+  ],
+  "attributes": [
+    {
+      "name": "grade_ppm",
+      "key": "e4b2c7d9-16a5-4f83-9c60-2d8e1a7b5f34",
+      "block_model_column_uuid": "e4b2c7d9-16a5-4f83-9c60-2d8e1a7b5f34",
+      "block_model_group_uuid": "f2a7c18d-95e4-4b63-8d20-7c1e4a9f6b35",
+      "attribute_type": "Float32",
+      "attribute_description": {
+        "discipline": "Geochemistry",
+        "type": "Gold grade",
+        "unit": "ppm"
+      }
+    },
+    {
+      "name": "oxide_grade_ppm",
+      "key": "a1f3c8d2-5b74-4e90-8a16-2d7c9e4f6b31",
+      "block_model_column_uuid": "a1f3c8d2-5b74-4e90-8a16-2d7c9e4f6b31",
+      "block_model_group_uuid": "f2a7c18d-95e4-4b63-8d20-7c1e4a9f6b35",
+      "attribute_type": "Float32"
+    },
+    {
+      "name": "sulphide_grade_ppm",
+      "key": "c4e7a1f9-2d58-4b60-9c35-6a8e1f3d7b42",
+      "block_model_column_uuid": "c4e7a1f9-2d58-4b60-9c35-6a8e1f3d7b42",
+      "block_model_group_uuid": "f2a7c18d-95e4-4b63-8d20-7c1e4a9f6b35",
+      "attribute_type": "Float32"
+    },
+    {
+      "name": "cutoff_grade_ppm",
+      "key": "7d2b9e4c-a163-4f85-8c70-1e6a3d9f5b24",
+      "block_model_column_uuid": "7d2b9e4c-a163-4f85-8c70-1e6a3d9f5b24",
+      "block_model_group_uuid": "f2a7c18d-95e4-4b63-8d20-7c1e4a9f6b35",
+      "attribute_type": "Float32"
+    },
+    {
+      "name": "resource_classification",
+      "key": "e8c1a6d3-4f72-4b90-9d25-7a3e1c8f6b49",
+      "block_model_column_uuid": "e8c1a6d3-4f72-4b90-9d25-7a3e1c8f6b49",
+      "block_model_group_uuid": "f2a7c18d-95e4-4b63-8d20-7c1e4a9f6b35",
+      "attribute_type": "Utf8"
+    },
+    {
+      "name": "mean_grade_ppm",
+      "key": "1e6a9c4d-b258-4f70-8d31-5a7e2c9f6b43",
+      "block_model_column_uuid": "1e6a9c4d-b258-4f70-8d31-5a7e2c9f6b43",
+      "block_model_group_uuid": "4d9e1b72-a6c3-4f80-95d2-8b6a3e7c1f49",
+      "attribute_type": "Float64"
+    },
+    {
+      "name": "median_grade_ppm",
+      "key": "b3f8d1a7-6c24-4e95-9b60-2a7e5d1f8c34",
+      "block_model_column_uuid": "b3f8d1a7-6c24-4e95-9b60-2a7e5d1f8c34",
+      "block_model_group_uuid": "4d9e1b72-a6c3-4f80-95d2-8b6a3e7c1f49",
+      "attribute_type": "Float64"
+    },
+    {
+      "name": "grade_variance",
+      "key": "6a2e7c9f-d145-4b80-8f36-1c5a9e3d7b24",
+      "block_model_column_uuid": "6a2e7c9f-d145-4b80-8f36-1c5a9e3d7b24",
+      "block_model_group_uuid": "4d9e1b72-a6c3-4f80-95d2-8b6a3e7c1f49",
+      "attribute_type": "Float64"
+    },
+    {
+      "name": "sample_count",
+      "key": "d7c4a9e1-3f68-4d20-9b75-6e1a8c5f2d43",
+      "block_model_column_uuid": "d7c4a9e1-3f68-4d20-9b75-6e1a8c5f2d43",
+      "block_model_group_uuid": "4d9e1b72-a6c3-4f80-95d2-8b6a3e7c1f49",
+      "attribute_type": "Int32"
+    },
+    {
+      "name": "outlier_flag",
+      "key": "2c9e6a4d-b751-4f83-8d20-7a3e1c5f9b46",
+      "block_model_column_uuid": "2c9e6a4d-b751-4f83-8d20-7a3e1c5f9b46",
+      "block_model_group_uuid": "4d9e1b72-a6c3-4f80-95d2-8b6a3e7c1f49",
+      "attribute_type": "Boolean"
+    },
+    {
+      "name": "estimation_variance",
+      "key": "f6a1d8c3-4e72-4b90-9c15-2a7e5f1d8b34",
+      "block_model_column_uuid": "f6a1d8c3-4e72-4b90-9c15-2a7e5f1d8b34",
+      "block_model_group_uuid": "b5f0a3c8-2e71-4d96-8b4f-1c7a9e3d6f20",
+      "attribute_type": "Float32"
+    },
+    {
+      "name": "weight",
+      "key": "5b2e9a7d-c164-4f80-8d35-1a6e3c9f7b42",
+      "block_model_column_uuid": "5b2e9a7d-c164-4f80-8d35-1a6e3c9f7b42",
+      "block_model_group_uuid": "b5f0a3c8-2e71-4d96-8b4f-1c7a9e3d6f20",
+      "attribute_type": "Float32"
+    },
+    {
+      "name": "neighbour_count",
+      "key": "c8d3e1a6-7f25-4b90-9a64-2e7c5d1f8b43",
+      "block_model_column_uuid": "c8d3e1a6-7f25-4b90-9a64-2e7c5d1f8b43",
+      "block_model_group_uuid": "b5f0a3c8-2e71-4d96-8b4f-1c7a9e3d6f20",
+      "attribute_type": "Int16"
+    },
+    {
+      "name": "search_radius",
+      "key": "9e4a7c2d-b153-4f86-8d70-6a1e3c9f5b24",
+      "block_model_column_uuid": "9e4a7c2d-b153-4f86-8d70-6a1e3c9f5b24",
+      "block_model_group_uuid": "b5f0a3c8-2e71-4d96-8b4f-1c7a9e3d6f20",
+      "attribute_type": "Float32"
+    },
+    {
+      "name": "search_azimuth",
+      "key": "7f3a9c1e-d268-4b50-8e74-2c6a1d9f5b43",
+      "block_model_column_uuid": "7f3a9c1e-d268-4b50-8e74-2c6a1d9f5b43",
+      "block_model_group_uuid": "b5f0a3c8-2e71-4d96-8b4f-1c7a9e3d6f20",
+      "attribute_type": "Float32"
+    },
+    {
+      "name": "estimate",
+      "key": "3f8a1c6e-b529-4d70-8f42-7a9e2c5d1b63",
+      "block_model_column_uuid": "3f8a1c6e-b529-4d70-8f42-7a9e2c5d1b63",
+      "block_model_group_uuid": "8c3e7a1f-d952-4b60-9e18-4f6a2c8d1b75",
+      "attribute_type": "Float32"
+    },
+    {
+      "name": "confidence",
+      "key": "4c1e8a6d-f273-4b90-9d45-7a2e5c1f8b36",
+      "block_model_column_uuid": "4c1e8a6d-f273-4b90-9d45-7a2e5c1f8b36",
+      "block_model_group_uuid": "8c3e7a1f-d952-4b60-9e18-4f6a2c8d1b75",
+      "attribute_type": "Float32"
+    },
+    {
+      "name": "lower_bound",
+      "key": "a7d2c9e4-5b61-4f80-8a35-1e6c3d9f7b42",
+      "block_model_column_uuid": "a7d2c9e4-5b61-4f80-8a35-1e6c3d9f7b42",
+      "block_model_group_uuid": "8c3e7a1f-d952-4b60-9e18-4f6a2c8d1b75",
+      "attribute_type": "Float32"
+    },
+    {
+      "name": "upper_bound",
+      "key": "e1b6a3d8-c475-4f90-9e20-6a7c1d5f8b34",
+      "block_model_column_uuid": "e1b6a3d8-c475-4f90-9e20-6a7c1d5f8b34",
+      "block_model_group_uuid": "8c3e7a1f-d952-4b60-9e18-4f6a2c8d1b75",
+      "attribute_type": "Float32"
+    },
+    {
+      "name": "estimate_class",
+      "key": "3f9e2c7a-d158-4b60-8d74-5a1e6c9f3b42",
+      "block_model_column_uuid": "3f9e2c7a-d158-4b60-8d74-5a1e6c9f3b42",
+      "block_model_group_uuid": "8c3e7a1f-d952-4b60-9e18-4f6a2c8d1b75",
+      "attribute_type": "Utf8"
+    },
+    {
+      "name": "discounted_value",
+      "key": "9a6e2b4c-f173-4d85-b0c9-5e1a8f3d6b27",
+      "block_model_column_uuid": "9a6e2b4c-f173-4d85-b0c9-5e1a8f3d6b27",
+      "block_model_group_uuid": "1b6d9f42-7e30-4c85-a1f6-9d3b2e8c5a74",
+      "attribute_type": "Float32"
+    },
+    {
+      "name": "recoverable_tonnage",
+      "key": "7a4e1c9d-b263-4f80-8d35-2e6a7c1f9b54",
+      "block_model_column_uuid": "7a4e1c9d-b263-4f80-8d35-2e6a7c1f9b54",
+      "block_model_group_uuid": "1b6d9f42-7e30-4c85-a1f6-9d3b2e8c5a74",
+      "attribute_type": "Float64"
+    },
+    {
+      "name": "diluted_grade",
+      "key": "d2c7a9e1-6f34-4b90-9a58-3e1c7d5f8b26",
+      "block_model_column_uuid": "d2c7a9e1-6f34-4b90-9a58-3e1c7d5f8b26",
+      "block_model_group_uuid": "1b6d9f42-7e30-4c85-a1f6-9d3b2e8c5a74",
+      "attribute_type": "Float32"
+    },
+    {
+      "name": "economic_value",
+      "key": "6e1a8c4d-b759-4f20-8d36-2a7e5c9f1b43",
+      "block_model_column_uuid": "6e1a8c4d-b759-4f20-8d36-2a7e5c9f1b43",
+      "block_model_group_uuid": "1b6d9f42-7e30-4c85-a1f6-9d3b2e8c5a74",
+      "attribute_type": "Float64"
+    },
+    {
+      "name": "eligibility_flag",
+      "key": "b9d4e2a7-1c65-4f80-9a34-7e2c5d1f8b46",
+      "block_model_column_uuid": "b9d4e2a7-1c65-4f80-9a34-7e2c5d1f8b46",
+      "block_model_group_uuid": "1b6d9f42-7e30-4c85-a1f6-9d3b2e8c5a74",
+      "attribute_type": "Boolean"
+    },
+    {
+      "name": "density",
+      "key": "2d8a5e1c-7b43-4f90-8d26-1a6e3c9f5b74",
+      "block_model_column_uuid": "2d8a5e1c-7b43-4f90-8d26-1a6e3c9f5b74",
+      "attribute_type": "Float32"
+    },
+    {
+      "name": "lithology_code",
+      "key": "8f3c1a6d-e254-4b90-9d75-2a7e5c1f8b36",
+      "block_model_column_uuid": "8f3c1a6d-e254-4b90-9d75-2a7e5c1f8b36",
+      "attribute_type": "Int32"
+    },
+    {
+      "name": "oxidation_state",
+      "key": "c1e7a4d9-5b62-4f80-8c35-6a2e9d1f7b43",
+      "block_model_column_uuid": "c1e7a4d9-5b62-4f80-8c35-6a2e9d1f7b43",
+      "attribute_type": "Utf8"
+    },
+    {
+      "name": "east",
+      "key": "4a9e2c7d-f153-4b90-8d64-1e6a3c9f5b27",
+      "block_model_column_uuid": "4a9e2c7d-f153-4b90-8d64-1e6a3c9f5b27",
+      "attribute_type": "Float64"
+    },
+    {
+      "name": "north",
+      "key": "e6b1d8a3-2c75-4f90-9a36-7e1c5d9f8b24",
+      "block_model_column_uuid": "e6b1d8a3-2c75-4f90-9a36-7e1c5d9f8b24",
+      "attribute_type": "Float64"
+    },
+    {
+      "name": "elevation",
+      "key": "1c7e9a4d-b265-4f80-8d31-5a2e6c9f7b43",
+      "block_model_column_uuid": "1c7e9a4d-b265-4f80-8d31-5a2e6c9f7b43",
+      "attribute_type": "Float64"
+    },
+    {
+      "name": "volume",
+      "key": "9d2a6e1c-f754-4b90-8c35-2a7e5d1f9b46",
+      "block_model_column_uuid": "9d2a6e1c-f754-4b90-8c35-2a7e5d1f9b46",
+      "attribute_type": "Float64"
+    },
+    {
+      "name": "domain",
+      "key": "5e1c8a7d-b243-4f90-9d65-1a7e3c5f8b29",
+      "block_model_column_uuid": "5e1c8a7d-b243-4f90-9d65-1a7e3c5f8b29",
+      "attribute_type": "Utf8"
+    },
+    {
+      "name": "block_active",
+      "key": "a4d9e2c7-6b15-4f80-8d34-7e1a5c9f2b63",
+      "block_model_column_uuid": "a4d9e2c7-6b15-4f80-8d34-7e1a5c9f2b63",
+      "attribute_type": "Boolean"
+    },
+    {
+      "name": "model_date",
+      "key": "7c2e5a9d-f164-4b90-8d37-2a6e1c9f5b48",
+      "block_model_column_uuid": "7c2e5a9d-f164-4b90-8d37-2a6e1c9f5b48",
+      "attribute_type": "Date32"
+    }
+  ],
+  "tags": {},
+  "extensions": {}
+}

--- a/examples/1.3.0/objects/block-model-6.json
+++ b/examples/1.3.0/objects/block-model-6.json
@@ -2,7 +2,7 @@
   "schema": "/objects/block-model/1.3.0/block-model.schema.json",
   "name": "Silver Scenario Block Model",
   "uuid": "d1c8a5f2-6e43-4b90-8d17-3f7a2c9e5b64",
-  "description": "Example block model with silver scenario attribute groups.",
+  "description": "Example block model with silver scenario block-model-attribute-groups.",
   "bounding_box": {
     "min_x": 0,
     "max_x": 15,

--- a/examples/1.3.0/objects/block-model-6.json
+++ b/examples/1.3.0/objects/block-model-6.json
@@ -1,0 +1,286 @@
+{
+  "schema": "/objects/block-model/1.3.0/block-model.schema.json",
+  "name": "Silver Scenario Block Model",
+  "uuid": "d1c8a5f2-6e43-4b90-8d17-3f7a2c9e5b64",
+  "description": "Example block model with silver scenario attribute groups.",
+  "bounding_box": {
+    "min_x": 0,
+    "max_x": 15,
+    "min_y": 0,
+    "max_y": 15,
+    "min_z": 0,
+    "max_z": 50.0
+  },
+  "coordinate_reference_system": {
+    "epsg_code": 1024
+  },
+  "block_model_uuid": "5e2a9d71-c4f8-4b36-9a05-1d7c3e8f6b20",
+  "block_model_version_uuid": "a7b3e9c4-1f65-4d82-8c30-6e2a9f5b7d14",
+  "geometry": {
+    "model_type": "flexible",
+    "origin": [
+      0.0,
+      0.0,
+      0.0
+    ],
+    "n_parent_blocks": [
+      10,
+      10,
+      20
+    ],
+    "parent_block_size": [
+      1.5,
+      1.5,
+      2.5
+    ],
+    "n_subblocks_per_parent": [
+      15,
+      64,
+      21
+    ],
+    "rotation": {
+      "dip_azimuth": 90.0,
+      "dip": 45.0,
+      "pitch": 15.0
+    }
+  },
+  "groups": [
+    {
+      "group_uuid": "c9e4a172-5b8d-4f63-90c1-7a2e6d8f3b45",
+      "parent_group_uuid": null,
+      "title": "Ag",
+      "tags": {
+        "commodity": "silver",
+        "reporting_unit": "g/t"
+      }
+    },
+    {
+      "group_uuid": "2f7c8d5a-e149-4b60-a3f8-6d1e9c4b7a25",
+      "parent_group_uuid": "c9e4a172-5b8d-4f63-90c1-7a2e6d8f3b45",
+      "title": "Economic scenarios",
+      "tags": {
+        "purpose": "resource evaluation"
+      }
+    },
+    {
+      "group_uuid": "7b1e6a3d-c859-4f20-8d74-9a2c5e1f6b38",
+      "parent_group_uuid": "2f7c8d5a-e149-4b60-a3f8-6d1e9c4b7a25",
+      "title": "Base case",
+      "is_hidden": true
+    },
+    {
+      "group_uuid": "e3d9b6a1-4c72-4f85-91e0-8b5a2d7c6f49",
+      "parent_group_uuid": "2f7c8d5a-e149-4b60-a3f8-6d1e9c4b7a25",
+      "title": "Upside case"
+    }
+  ],
+  "attributes": [
+    {
+      "name": "grade_gpt",
+      "key": "6c2a8f1d-b754-4e90-8c36-1e7a5d9b3f42",
+      "block_model_column_uuid": "6c2a8f1d-b754-4e90-8c36-1e7a5d9b3f42",
+      "block_model_group_uuid": "c9e4a172-5b8d-4f63-90c1-7a2e6d8f3b45",
+      "attribute_type": "Float32",
+      "attribute_description": {
+        "discipline": "Geochemistry",
+        "type": "Silver grade",
+        "unit": "g/t"
+      }
+    },
+    {
+      "name": "oxide_grade_gpt",
+      "key": "b1e6a3d9-5c72-4f80-8d24-7a1e9c5f6b43",
+      "block_model_column_uuid": "b1e6a3d9-5c72-4f80-8d24-7a1e9c5f6b43",
+      "block_model_group_uuid": "c9e4a172-5b8d-4f63-90c1-7a2e6d8f3b45",
+      "attribute_type": "Float32"
+    },
+    {
+      "name": "sulphide_grade_gpt",
+      "key": "6c1a8e4d-b253-4f90-9d76-2a7e5c1f8b34",
+      "block_model_column_uuid": "6c1a8e4d-b253-4f90-9d76-2a7e5c1f8b34",
+      "block_model_group_uuid": "c9e4a172-5b8d-4f63-90c1-7a2e6d8f3b45",
+      "attribute_type": "Float32"
+    },
+    {
+      "name": "cutoff_grade_gpt",
+      "key": "d8a2c7e1-4f65-4b90-8d31-6a7e1c9f5b24",
+      "block_model_column_uuid": "d8a2c7e1-4f65-4b90-8d31-6a7e1c9f5b24",
+      "block_model_group_uuid": "c9e4a172-5b8d-4f63-90c1-7a2e6d8f3b45",
+      "attribute_type": "Float32"
+    },
+    {
+      "name": "resource_classification",
+      "key": "3e9c1a7d-b452-4f80-9d26-5a7e2c1f8b63",
+      "block_model_column_uuid": "3e9c1a7d-b452-4f80-9d26-5a7e2c1f8b63",
+      "block_model_group_uuid": "c9e4a172-5b8d-4f63-90c1-7a2e6d8f3b45",
+      "attribute_type": "Utf8"
+    },
+    {
+      "name": "evaluation_count",
+      "key": "9a4e2c7d-f163-4b90-8d75-1e6a3c9f5b24",
+      "block_model_column_uuid": "9a4e2c7d-f163-4b90-8d75-1e6a3c9f5b24",
+      "block_model_group_uuid": "2f7c8d5a-e149-4b60-a3f8-6d1e9c4b7a25",
+      "attribute_type": "Int16"
+    },
+    {
+      "name": "discount_rate",
+      "key": "e2d7a5c9-1b64-4f80-9d38-6a1e7c5f8b42",
+      "block_model_column_uuid": "e2d7a5c9-1b64-4f80-9d38-6a1e7c5f8b42",
+      "block_model_group_uuid": "2f7c8d5a-e149-4b60-a3f8-6d1e9c4b7a25",
+      "attribute_type": "Float64"
+    },
+    {
+      "name": "metal_price",
+      "key": "5f1a9e4d-c273-4b90-8d65-2a7e1c9f5b34",
+      "block_model_column_uuid": "5f1a9e4d-c273-4b90-8d65-2a7e1c9f5b34",
+      "block_model_group_uuid": "2f7c8d5a-e149-4b60-a3f8-6d1e9c4b7a25",
+      "attribute_type": "Float64"
+    },
+    {
+      "name": "processing_cost",
+      "key": "c7e1a6d3-5b94-4f80-9d20-7a2e5c1f8b46",
+      "block_model_column_uuid": "c7e1a6d3-5b94-4f80-9d20-7a2e5c1f8b46",
+      "block_model_group_uuid": "2f7c8d5a-e149-4b60-a3f8-6d1e9c4b7a25",
+      "attribute_type": "Float64"
+    },
+    {
+      "name": "recovery",
+      "key": "1d8a4e7c-f265-4b90-8d31-6a2e9c5f1b43",
+      "block_model_column_uuid": "1d8a4e7c-f265-4b90-8d31-6a2e9c5f1b43",
+      "block_model_group_uuid": "2f7c8d5a-e149-4b60-a3f8-6d1e9c4b7a25",
+      "attribute_type": "Float32"
+    },
+    {
+      "name": "net_value",
+      "key": "b8d3e6a9-25f1-4c70-9b48-2a7e5d1f6c34",
+      "block_model_column_uuid": "b8d3e6a9-25f1-4c70-9b48-2a7e5d1f6c34",
+      "block_model_group_uuid": "7b1e6a3d-c859-4f20-8d74-9a2c5e1f6b38",
+      "attribute_type": "Float64"
+    },
+    {
+      "name": "ore_tonnage",
+      "key": "8c3e1a6d-b754-4f90-9d26-5a7e2c1f8b43",
+      "block_model_column_uuid": "8c3e1a6d-b754-4f90-9d26-5a7e2c1f8b43",
+      "block_model_group_uuid": "7b1e6a3d-c859-4f20-8d74-9a2c5e1f6b38",
+      "attribute_type": "Float64"
+    },
+    {
+      "name": "gross_revenue",
+      "key": "4e9a2c7d-f163-4b80-8d75-1a6e3c9f5b24",
+      "block_model_column_uuid": "4e9a2c7d-f163-4b80-8d75-1a6e3c9f5b24",
+      "block_model_group_uuid": "7b1e6a3d-c859-4f20-8d74-9a2c5e1f6b38",
+      "attribute_type": "Float64"
+    },
+    {
+      "name": "operating_cost",
+      "key": "d1c7a5e9-6b24-4f90-8d36-2a7e1c9f5b43",
+      "block_model_column_uuid": "d1c7a5e9-6b24-4f90-8d36-2a7e1c9f5b43",
+      "block_model_group_uuid": "7b1e6a3d-c859-4f20-8d74-9a2c5e1f6b38",
+      "attribute_type": "Float64"
+    },
+    {
+      "name": "operating_margin",
+      "key": "7a2e9c4d-b153-4f80-9d65-6a1e3c5f8b24",
+      "block_model_column_uuid": "7a2e9c4d-b153-4f80-9d65-6a1e3c5f8b24",
+      "block_model_group_uuid": "7b1e6a3d-c859-4f20-8d74-9a2c5e1f6b38",
+      "attribute_type": "Float64"
+    },
+    {
+      "name": "alternative_value",
+      "key": "4a9f2c7e-d638-4b15-8e70-5c1a9d3f6b28",
+      "block_model_column_uuid": "4a9f2c7e-d638-4b15-8e70-5c1a9d3f6b28",
+      "block_model_group_uuid": "e3d9b6a1-4c72-4f85-91e0-8b5a2d7c6f49",
+      "attribute_type": "Float64"
+    },
+    {
+      "name": "recoverable_tonnage",
+      "key": "b6d1e8a3-4c75-4f90-9a26-7e2c5d1f8b43",
+      "block_model_column_uuid": "b6d1e8a3-4c75-4f90-9a26-7e2c5d1f8b43",
+      "block_model_group_uuid": "e3d9b6a1-4c72-4f85-91e0-8b5a2d7c6f49",
+      "attribute_type": "Float64"
+    },
+    {
+      "name": "projected_revenue",
+      "key": "2c8e5a7d-f164-4b90-8d35-1a6e3c9f5b42",
+      "block_model_column_uuid": "2c8e5a7d-f164-4b90-8d35-1a6e3c9f5b42",
+      "block_model_group_uuid": "e3d9b6a1-4c72-4f85-91e0-8b5a2d7c6f49",
+      "attribute_type": "Float64"
+    },
+    {
+      "name": "projected_cost",
+      "key": "e7a2c9d1-5b63-4f80-9d24-6a1e7c5f8b43",
+      "block_model_column_uuid": "e7a2c9d1-5b63-4f80-9d24-6a1e7c5f8b43",
+      "block_model_group_uuid": "e3d9b6a1-4c72-4f85-91e0-8b5a2d7c6f49",
+      "attribute_type": "Float64"
+    },
+    {
+      "name": "projected_margin",
+      "key": "6d1a8e4c-b275-4f90-8d36-2a7e5c9f1b43",
+      "block_model_column_uuid": "6d1a8e4c-b275-4f90-8d36-2a7e5c9f1b43",
+      "block_model_group_uuid": "e3d9b6a1-4c72-4f85-91e0-8b5a2d7c6f49",
+      "attribute_type": "Float64"
+    },
+    {
+      "name": "density",
+      "key": "a3e7c1d9-5b64-4f80-8d25-7a1e9c5f6b43",
+      "block_model_column_uuid": "a3e7c1d9-5b64-4f80-8d25-7a1e9c5f6b43",
+      "attribute_type": "Float32"
+    },
+    {
+      "name": "lithology_code",
+      "key": "5c1a8e4d-b273-4f90-9d65-2a7e1c9f5b34",
+      "block_model_column_uuid": "5c1a8e4d-b273-4f90-9d65-2a7e1c9f5b34",
+      "attribute_type": "Int32"
+    },
+    {
+      "name": "alteration_code",
+      "key": "d9e2a7c1-4b65-4f80-8d36-6a1e3c9f5b24",
+      "block_model_column_uuid": "d9e2a7c1-4b65-4f80-8d36-6a1e3c9f5b24",
+      "attribute_type": "Int16"
+    },
+    {
+      "name": "east",
+      "key": "1a7e9c4d-b253-4f90-8d64-5a2e6c1f8b43",
+      "block_model_column_uuid": "1a7e9c4d-b253-4f90-8d64-5a2e6c1f8b43",
+      "attribute_type": "Float64"
+    },
+    {
+      "name": "north",
+      "key": "8d3a1e6c-f274-4b90-9d35-2a7e5c1f8b46",
+      "block_model_column_uuid": "8d3a1e6c-f274-4b90-9d35-2a7e5c1f8b46",
+      "attribute_type": "Float64"
+    },
+    {
+      "name": "elevation",
+      "key": "c6e1a9d3-5b24-4f80-8d75-1a7e3c9f5b42",
+      "block_model_column_uuid": "c6e1a9d3-5b24-4f80-8d75-1a7e3c9f5b42",
+      "attribute_type": "Float64"
+    },
+    {
+      "name": "volume",
+      "key": "4f8a2c7d-b163-4f90-9d25-6a1e3c5f8b47",
+      "block_model_column_uuid": "4f8a2c7d-b163-4f90-9d25-6a1e3c5f8b47",
+      "attribute_type": "Float64"
+    },
+    {
+      "name": "domain",
+      "key": "e1c7a4d9-5b62-4f80-8d36-2a7e9c1f5b43",
+      "block_model_column_uuid": "e1c7a4d9-5b62-4f80-8d36-2a7e9c1f5b43",
+      "attribute_type": "Utf8"
+    },
+    {
+      "name": "block_active",
+      "key": "7a3e1c9d-f264-4b90-8d75-5a2e6c1f9b43",
+      "block_model_column_uuid": "7a3e1c9d-f264-4b90-8d75-5a2e6c1f9b43",
+      "attribute_type": "Boolean"
+    },
+    {
+      "name": "model_date",
+      "key": "b2d8a5e1-6c74-4f90-9d35-2a7e1c5f8b46",
+      "block_model_column_uuid": "b2d8a5e1-6c74-4f90-9d35-2a7e1c5f8b46",
+      "attribute_type": "Date32"
+    }
+  ],
+  "tags": {},
+  "extensions": {}
+}

--- a/schema/components/block-model-attribute-group/1.0.0/block-model-attribute-group.schema.json
+++ b/schema/components/block-model-attribute-group/1.0.0/block-model-attribute-group.schema.json
@@ -1,0 +1,57 @@
+{
+  "$id": "/components/block-model-attribute-group/1.0.0/block-model-attribute-group.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Column group metadata",
+  "type": "object",
+  "properties": {
+    "group_uuid": {
+      "type": "string",
+      "format": "uuid",
+      "title": "Group UUID",
+      "description": "Unique identifier for the group."
+    },
+    "is_hidden": {
+      "type": "boolean",
+      "default": false,
+      "title": "Is Hidden",
+      "description": "When true, the group's direct member columns are excluded from wildcard queries (unless include_hidden is set in the query)."
+    },
+    "missing_column_policy": {
+      "type": "string",
+      "enum": [
+        "INHERIT",
+        "USE_PREVIOUS",
+        "SET_NULL",
+        "REJECT"
+      ],
+      "title": "Missing Column Policy",
+      "default": "USE_PREVIOUS",
+      "description": "Defines the update behaviour, for all columns in the group, for columns that do not have a value provided."
+    },
+    "parent_group_uuid": {
+      "oneOf": [
+        {
+          "type": "string",
+          "format": "uuid"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "title": "Parent Group UUID",
+      "description": "Identifier of the parent group. Null means the group is a 'top-level' group."
+    },
+    "tags": {
+      "type": "object",
+      "title": "Tags",
+      "description": "Publisher-supplied free-form metadata for the group, as a JSON object. Keys must be 1-100 chars and cannot contain leading whitespace or dot, or the characters `/ \\ : > < | ? \" *`; keys are unique case-insensitively. Values may be any JSON-compatible type. A single `tags` object serialised as UTF-8 JSON must be at most 10 KiB."
+    },
+    "title": {
+      "type": "string",
+      "title": "Title",
+      "default": "",
+      "description": "'Human-readable label for the group, unique across the parent group, or across top-level groups if no parent. They must be 1-100 chars and cannot contain leading whitespace or dot, or the characters `/ \\ : > < | ? \" *`. Must not contain the qualified title separator `▸`.'"
+    }
+  },
+  "additionalProperties": false
+}

--- a/schema/components/block-model-attribute-group/1.0.0/block-model-attribute-group.schema.json
+++ b/schema/components/block-model-attribute-group/1.0.0/block-model-attribute-group.schema.json
@@ -19,13 +19,13 @@
     "missing_column_policy": {
       "type": "string",
       "enum": [
-        "INHERIT",
-        "USE_PREVIOUS",
-        "SET_NULL",
-        "REJECT"
+        "inherit",
+        "use_previous",
+        "set_null",
+        "reject"
       ],
       "title": "Missing Column Policy",
-      "default": "USE_PREVIOUS",
+      "default": "use_previous",
       "description": "Defines the update behaviour, for all columns in the group, for columns that do not have a value provided."
     },
     "parent_group_uuid": {

--- a/schema/components/block-model-attribute-group/1.0.0/block-model-attribute-group.schema.json
+++ b/schema/components/block-model-attribute-group/1.0.0/block-model-attribute-group.schema.json
@@ -1,7 +1,7 @@
 {
   "$id": "/components/block-model-attribute-group/1.0.0/block-model-attribute-group.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "description": "Column group metadata",
+  "description": "A block-model-attribute-group represents metadata about a group of attributes (columns).",
   "type": "object",
   "properties": {
     "group_uuid": {

--- a/schema/components/block-model-attribute-group/1.0.0/block-model-attribute-group.schema.json
+++ b/schema/components/block-model-attribute-group/1.0.0/block-model-attribute-group.schema.json
@@ -49,12 +49,12 @@
     "title": {
       "type": "string",
       "title": "Title",
-      "default": "",
       "description": "Human-readable label for the group, unique across the parent group, or across top-level groups if no parent. Titles must be 1-100 characters and cannot contain leading whitespace or dot, or the characters `/ \\ : > < | ? \" *`. Must not contain the qualified title separator `▸`."
     }
   },
   "required": [
-    "group_uuid"
+    "group_uuid",
+    "title"
   ],
   "additionalProperties": false
 }

--- a/schema/components/block-model-attribute-group/1.0.0/block-model-attribute-group.schema.json
+++ b/schema/components/block-model-attribute-group/1.0.0/block-model-attribute-group.schema.json
@@ -14,7 +14,7 @@
       "type": "boolean",
       "default": false,
       "title": "Is Hidden",
-      "description": "When true, the group's direct member columns are excluded from wildcard queries (unless include_hidden is set in the query)."
+      "description": "When true, indicates that the Block Model Service will exclude group members from wildcard queries by default."
     },
     "missing_column_policy": {
       "type": "string",
@@ -26,7 +26,7 @@
       ],
       "title": "Missing Column Policy",
       "default": "use_previous",
-      "description": "Defines the update behaviour, for all columns in the group, for columns that do not have a value provided."
+      "description": "Defines the update behaviour for all columns in the group that do not have a value provided."
     },
     "parent_group_uuid": {
       "oneOf": [
@@ -44,7 +44,7 @@
     "tags": {
       "type": "object",
       "title": "Tags",
-      "description": "Publisher-supplied free-form metadata for the group, as a JSON object. Keys must be 1-100 chars and cannot contain leading whitespace or dot, or the characters `/ \\ : > < | ? \" *`; keys are unique case-insensitively. Values may be any JSON-compatible type. A single `tags` object serialised as UTF-8 JSON must be at most 10 KiB."
+      "description": "Publisher-supplied free-form metadata for the group, as a JSON object. Keys must be 1-100 characters and cannot contain leading whitespace or dot, or the characters `/ \\ : > < | ? \" *`; keys are unique case-insensitively. Values may be any JSON-compatible type. A single `tags` object serialised as UTF-8 JSON must be at most 10 KiB."
     },
     "title": {
       "type": "string",

--- a/schema/components/block-model-attribute-group/1.0.0/block-model-attribute-group.schema.json
+++ b/schema/components/block-model-attribute-group/1.0.0/block-model-attribute-group.schema.json
@@ -1,7 +1,7 @@
 {
   "$id": "/components/block-model-attribute-group/1.0.0/block-model-attribute-group.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "description": "A block-model-attribute-group represents metadata about a group of attributes (columns).",
+  "description": "Metadata for a named group of block model attributes (columns), optionally nested within a parent group.",
   "type": "object",
   "properties": {
     "group_uuid": {
@@ -50,7 +50,7 @@
       "type": "string",
       "title": "Title",
       "default": "",
-      "description": "'Human-readable label for the group, unique across the parent group, or across top-level groups if no parent. They must be 1-100 chars and cannot contain leading whitespace or dot, or the characters `/ \\ : > < | ? \" *`. Must not contain the qualified title separator `▸`.'"
+      "description": "Human-readable label for the group, unique across the parent group, or across top-level groups if no parent. Titles must be 1-100 characters and cannot contain leading whitespace or dot, or the characters `/ \\ : > < | ? \" *`. Must not contain the qualified title separator `▸`."
     }
   },
   "additionalProperties": false

--- a/schema/components/block-model-attribute-group/1.0.0/block-model-attribute-group.schema.json
+++ b/schema/components/block-model-attribute-group/1.0.0/block-model-attribute-group.schema.json
@@ -53,5 +53,8 @@
       "description": "Human-readable label for the group, unique across the parent group, or across top-level groups if no parent. Titles must be 1-100 characters and cannot contain leading whitespace or dot, or the characters `/ \\ : > < | ? \" *`. Must not contain the qualified title separator `▸`."
     }
   },
+  "required": [
+    "group_uuid"
+  ],
   "additionalProperties": false
 }

--- a/schema/components/block-model-attribute/1.3.0/block-model-attribute.schema.json
+++ b/schema/components/block-model-attribute/1.3.0/block-model-attribute.schema.json
@@ -35,7 +35,7 @@
           "format": "uuid"
         },
         "block_model_group_uuid": {
-          "description": "The unique ID of the block-model-attribute-group to which the attribute belongs.",
+          "description": "The unique ID of the attribute group (column group) that the attribute belongs to.",
           "type": "string",
           "format": "uuid"
         }

--- a/schema/components/block-model-attribute/1.3.0/block-model-attribute.schema.json
+++ b/schema/components/block-model-attribute/1.3.0/block-model-attribute.schema.json
@@ -1,0 +1,49 @@
+{
+  "$id": "/components/block-model-attribute/1.3.0/block-model-attribute.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "A block model attribute stored by the Block Model Service. Covers both continuous and categorical attributes.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "/components/base-continuous-attribute/1.1.0/base-continuous-attribute.schema.json"
+    },
+    {
+      "properties": {
+        "attribute_type": {
+          "description": "The data type of the attribute as stored in the Block Model Service.",
+          "enum": [
+            "Boolean",
+            "Utf8",
+            "Int8",
+            "Int16",
+            "Int32",
+            "Int64",
+            "UInt8",
+            "UInt16",
+            "UInt32",
+            "UInt64",
+            "Float16",
+            "Float32",
+            "Float64",
+            "Date32",
+            "Timestamp"
+          ]
+        },
+        "block_model_column_uuid": {
+          "description": "The unique ID of the attribute on the block model.",
+          "type": "string",
+          "format": "uuid"
+        },
+        "block_model_group_uuid": {
+          "description": "The unique ID of the column group that that the attribute belongs to.",
+          "type": "string",
+          "format": "uuid"
+        }
+      }
+    }
+  ],
+  "required": [
+    "attribute_type",
+    "block_model_column_uuid"
+  ]
+}

--- a/schema/components/block-model-attribute/1.3.0/block-model-attribute.schema.json
+++ b/schema/components/block-model-attribute/1.3.0/block-model-attribute.schema.json
@@ -35,7 +35,7 @@
           "format": "uuid"
         },
         "block_model_group_uuid": {
-          "description": "The unique ID of the column group that that the attribute belongs to.",
+          "description": "The unique ID of the block-model-attribute-group to which the attribute belongs.",
           "type": "string",
           "format": "uuid"
         }

--- a/schema/geoscience-objects.schema.json
+++ b/schema/geoscience-objects.schema.json
@@ -14,6 +14,9 @@
       "$ref": "/objects/block-model/1.2.0/block-model.schema.json"
     },
     {
+      "$ref": "/objects/block-model/1.3.0/block-model.schema.json"
+    },
+    {
       "$ref": "/objects/design-geometry/1.0.1/design-geometry.schema.json"
     },
     {

--- a/schema/objects/block-model/1.3.0/block-model.schema.json
+++ b/schema/objects/block-model/1.3.0/block-model.schema.json
@@ -1,0 +1,65 @@
+{
+  "$id": "/objects/block-model/1.3.0/block-model.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "A reference to a block model stored in the Block Model Service.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "/components/base-spatial-data-properties/1.1.0/base-spatial-data-properties.schema.json"
+    },
+    {
+      "properties": {
+        "schema": {
+          "const": "/objects/block-model/1.3.0/block-model.schema.json"
+        },
+        "block_model_uuid": {
+          "description": "The unique ID of the block model in the Block Model Service.",
+          "type": "string",
+          "format": "uuid"
+        },
+        "block_model_version_uuid": {
+          "description": "The unique ID of this version of the block model in the Block Model Service.",
+          "type": "string",
+          "format": "uuid"
+        },
+        "geometry": {
+          "description": "The geometry (including subblocking parameters, if applicable) of the block model.",
+          "oneOf": [
+            {
+              "$ref": "/components/block-model-flexible-structure/1.0.0/block-model-flexible-structure.schema.json"
+            },
+            {
+              "$ref": "/components/block-model-fully-subblocked-structure/1.0.0/block-model-fully-subblocked-structure.schema.json"
+            },
+            {
+              "$ref": "/components/block-model-regular-structure/1.0.0/block-model-regular-structure.schema.json"
+            },
+            {
+              "$ref": "/components/block-model-variable-octree-structure/1.0.0/block-model-variable-octree-structure.schema.json"
+            }
+          ]
+        },
+        "attributes": {
+          "description": "The attributes found on this version of the block model.",
+          "type": "array",
+          "items": {
+            "$ref": "/components/block-model-attribute/1.3.0/block-model-attribute.schema.json"
+          }
+        },
+        "groups": {
+          "description": "The attribute groups available on this blockmodel. Note that group memberships are not included in this data; group memberships are set by a uuid pointer in `attributes`.",
+          "type": "array",
+          "items": {
+            "$ref": "/components/block-model-attribute-group/1.0.0/block-model-attribute-group.schema.json"
+          }
+        }
+      }
+    }
+  ],
+  "required": [
+    "schema",
+    "block_model_uuid",
+    "geometry"
+  ],
+  "unevaluatedProperties": false
+}

--- a/schema/objects/block-model/1.3.0/block-model.schema.json
+++ b/schema/objects/block-model/1.3.0/block-model.schema.json
@@ -47,7 +47,7 @@
           }
         },
         "groups": {
-          "description": "The attribute groups available on this blockmodel. Note that group memberships are not included in this data; group memberships are set by a uuid pointer in `attributes`.",
+          "description": "The block-model-attribute-groups available on this block model. Attribute membership is set by the `block_model_group_uuid` property.",
           "type": "array",
           "items": {
             "$ref": "/components/block-model-attribute-group/1.0.0/block-model-attribute-group.schema.json"

--- a/tests/test_json_examples.py
+++ b/tests/test_json_examples.py
@@ -11,8 +11,8 @@
 
 import pytest
 
-from tools.common import json_file_to_dict
-from tools.example_instances import example_schema_dict, generate_all_example_paths, validate_data
+from tools.common import generate_all_paths, json_file_to_dict
+from tools.example_instances import example_schema_dict, examples_base_path, generate_all_example_paths, validate_data
 
 
 @pytest.mark.parametrize("example_path", generate_all_example_paths())
@@ -20,3 +20,49 @@ def test_validate_examples(example_path):
     example = json_file_to_dict(example_path)
     example_schema = example_schema_dict(example)
     validate_data(example, example_schema)
+
+
+@pytest.mark.parametrize(
+    "example_path",
+    generate_all_paths(examples_base_path(), "/**/block-model*.json"),
+)
+def test_block_model_group_refs_are_coherent(example_path: str) -> None:
+    """Check that group parent and attribute membership references are coherent in the examples.
+
+    There are a couple of key rules that are not structurally enforced in the schema, but the
+    examples should definitely get right:
+
+    1. There should not be a cycle between attribute groups - following parent_group_uuid should not
+       loop back to itself.
+    2. Every parent_group_uuid should be an actual valid parent_group_uuid
+    3. The block_model_group_uuid on a block-model-attribute, if not null, should refer to an
+       actual group's uuid.
+
+    While the schema doesn't directly enfroce these constraints - they are not structural and
+    are enforced service-side - we should not be publishing examples that breach those rules.
+    """
+    example = json_file_to_dict(example_path)
+
+    groups = example.get("groups", [])
+    group_ids = {group["group_uuid"] for group in groups}
+    assert len(group_ids) == len(groups), f"{example_path}: group UUIDs must be unique"
+
+    for group in groups:
+        parent_group_uuid = group.get("parent_group_uuid")
+        if parent_group_uuid is not None:
+            assert parent_group_uuid in group_ids, f"{example_path}: parent group UUID must reference a group"
+
+        ancestor_ids = {group["group_uuid"]}
+        while parent_group_uuid is not None:
+            assert parent_group_uuid not in ancestor_ids, f"{example_path}: group hierarchy must not be circular"
+            ancestor_ids.add(parent_group_uuid)
+            parent_group_uuid = next(
+                candidate.get("parent_group_uuid")
+                for candidate in groups
+                if candidate["group_uuid"] == parent_group_uuid
+            )
+
+    for attribute in example.get("attributes", []):
+        group_uuid = attribute.get("block_model_group_uuid")
+        if group_uuid is not None:
+            assert group_uuid in group_ids, f"{example_path}: attribute group UUID must reference a group"

--- a/tests/test_json_examples.py
+++ b/tests/test_json_examples.py
@@ -44,23 +44,18 @@ def test_block_model_group_refs_are_coherent(example_path: str) -> None:
     example = json_file_to_dict(example_path)
 
     groups = example.get("groups", [])
-    group_ids = {group["group_uuid"] for group in groups}
+    groups_by_id = {group["group_uuid"]: group for group in groups}
+    group_ids = set(groups_by_id)
     assert len(group_ids) == len(groups), f"{example_path}: group UUIDs must be unique"
 
     for group in groups:
         parent_group_uuid = group.get("parent_group_uuid")
-        if parent_group_uuid is not None:
-            assert parent_group_uuid in group_ids, f"{example_path}: parent group UUID must reference a group"
-
         ancestor_ids = {group["group_uuid"]}
         while parent_group_uuid is not None:
+            assert parent_group_uuid in group_ids, f"{example_path}: parent group UUID must reference a group"
             assert parent_group_uuid not in ancestor_ids, f"{example_path}: group hierarchy must not be circular"
             ancestor_ids.add(parent_group_uuid)
-            parent_group_uuid = next(
-                candidate.get("parent_group_uuid")
-                for candidate in groups
-                if candidate["group_uuid"] == parent_group_uuid
-            )
+            parent_group_uuid = groups_by_id[parent_group_uuid].get("parent_group_uuid")
 
     for attribute in example.get("attributes", []):
         group_uuid = attribute.get("block_model_group_uuid")


### PR DESCRIPTION
<!--
Thank you for taking the time to make a pull request.

Please review our [contribution guide](https://github.com/seequentevo/evo-schemas/blob/main/CONTRIBUTING.md) and our
[code of conduct](https://github.com/seequentevo/evo-schemas/blob/main/CONTRIBUTING.md) before opening your first
pull request.

By making a pull request, you confirm you agree to our Contributor License Agreement (CLA).
-->

## Description

Adds schema support for the (currently in preview) column groups feature in blocksync .

This involves:

* a new component ( `schemas/components/block-model-attribute-group `) 
* revisions of ( `schemas/components/block-model-attribute` ) and ( `schemas/objects/block-model-attribute`   ) to bear the relevent relationships/mapping

2 new examples are added (block-model-5 and block-model-6) . To validate that the data in the examples is somewhat coherent, I added a parameterized test case to validate the cross-references in the examples are valid - this isn't enforced by the schema, but ensures the examples aren't too nonsensical.

**Note** When approved, merging this may be delayed until we confirm we're ready to move the feature out of preview.

closes #79 

## Checklist

- [x] I have read the contributing guide and the code of conduct

