### PR TITLE
Fix: backslash syntax handling codegen

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,6 +20,7 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"
     runs-on: ubuntu-latest
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evo-schemas"
-version = "2026.8.28"
+version = "2026.9.9"
 authors = [
     { name = "Seequent", email = "support@seequent.com" }
 ]
@@ -8,7 +8,7 @@ description = "Seequent Geoscience Object Schemas define metadata and data seria
 keywords = []
 readme = "README.pypi.md"
 license-files = ["LICENSE.md"]
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.15"
 
 classifiers = [
     "Programming Language :: Python",
@@ -33,12 +33,16 @@ test = [
     "pytest-subtests==0.13.1",
     "ruff==0.8.1",
     "semver==3.0.2",
+    "tomli >= 2.0.1; python_version < '3.11'", # drop-in replacement for the built-in tomllib in Python < 3.11
+    "pyyaml>=6.0.3",
 ]
 
 tools = [
     "evo-schemas[test]",
     "GitPython>=3.1.43",
     "PyGithub>=2.4.0",
+    "packaging>=26.3",
+
 ]
 
 examples = [

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,50 @@
+"""Test that our github test matrix matches the supported python versions."""
+import itertools
+from typing import TYPE_CHECKING
+
+import yaml
+
+if TYPE_CHECKING:
+    # Hide the import shenanigans that follow from our IDE / type-checkers
+    import tomllib
+else:
+    # In reality we need to deal with tomllib not being available for
+    # python3.10, by using the backport package tomli.
+    try:
+        import tomllib
+    except ModuleNotFoundError:
+        import tomli as tomllib
+
+from pathlib import Path
+
+from packaging.specifiers import SpecifierSet
+
+
+def _get_required_python() -> SpecifierSet:
+    pyproj_data = tomllib.loads((Path(__file__).parents[1] / "pyproject.toml").read_text())
+    requires_python = pyproj_data["project"]["requires-python"]
+    return SpecifierSet(requires_python)
+
+
+def _get_allowed_python_versions(spec: SpecifierSet) -> list[str]:
+    candidates = [
+        f"{major}.{minor}"
+        for major, minor in itertools.product(
+            ["3", "4"],  # major versions, even including a hypothetical python 4.x
+            range(0, 50),  # minor versions up to 50
+        )
+    ]
+    return list(spec.filter(candidates))
+
+
+def _get_tested_pythons():
+    test_workflow_file = Path(__file__).parents[1] / ".github" / "workflows" / "run-tests.yml"
+    assert test_workflow_file.exists()
+    workflow_data = yaml.safe_load(test_workflow_file.read_text())
+    return workflow_data["jobs"]["unit-tests"]["strategy"]["matrix"]["python-version"]
+
+
+def test_supported_python_version_matches_gha_matrix():
+    required_python_spec = _get_required_python()
+    allowed_pythons = _get_allowed_python_versions(required_python_spec)
+    assert allowed_pythons == _get_tested_pythons()

--- a/tools/code_generator/python_generator.py
+++ b/tools/code_generator/python_generator.py
@@ -282,6 +282,9 @@ class PythonGenerator:
         return validators
 
     def _doc_string(self, line):
+        # Escape backslashes and quotes so the description can't produce invalid escape
+        # sequences or break out of the surrounding """ docstring delimiters.
+        line = line.replace("\\", "\\\\").replace('"', '\\"')
         if "\n" in line:
             # PEP-257
             for idx, part in enumerate(line.split("\n")):


### PR DESCRIPTION
<!--
Thank you for taking the time to make a pull request.

Please review our [contribution guide](https://github.com/seequentevo/evo-schemas/blob/main/CONTRIBUTING.md) and our
[code of conduct](https://github.com/seequentevo/evo-schemas/blob/main/CONTRIBUTING.md) before opening your first
pull request.

By making a pull request, you confirm you agree to our Contributor License Agreement (CLA).
-->

## Description

Previous PR on blockmodel attribute groups exposed a SyntaxError in python 3.14.
This fixes the syntax error, and tightens the python version to ensure we're only marking the package compatible with python versions we actively test. A new test case validates that the project's `requires-python` corresponds to the github workflow's python versions matrix to enforce they remain synced in the future.

## Checklist

- [x] I have read the contributing guide and the code of conduct
