### PR TITLE
Add SEO metadata to Geoscience Objects docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,8 @@
+---
+seoTitle: Geoscience Objects Data Structures | Seequent Developer
+description: Explore Geoscience Objects data structures for Seequent Evo, supporting trustworthy data, integrations, and custom workflows.
+---
+
 # Geoscience Objects
 
 Geoscience Objects is Seequent's open schema standard for geoscience data. It defines how geoscience datasets — point clouds, drillhole campaigns, geological models, geophysical surveys, and more — are structured and serialised for exchange between applications and services.

--- a/docs/schemas/components/attribute-description.md
+++ b/docs/schemas/components/attribute-description.md
@@ -1,3 +1,8 @@
+---
+seoTitle: attribute-description Component for Evo Schemas | Seequent Developer
+description: Review the attribute description component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/attribute-description-1.1.0.md';
 

--- a/docs/schemas/components/attribute-list-property.md
+++ b/docs/schemas/components/attribute-list-property.md
@@ -1,3 +1,8 @@
+---
+seoTitle: attribute-list-property Component for Evo Schemas | Seequent Developer
+description: Review the attribute list property component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/attribute-list-property-1.2.0.md';
 

--- a/docs/schemas/components/base-attribute.md
+++ b/docs/schemas/components/base-attribute.md
@@ -1,3 +1,8 @@
+---
+seoTitle: base-attribute Component for Evo Schemas | Seequent Developer
+description: Review the base attribute component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/base-attribute-1.0.0.md';
 

--- a/docs/schemas/components/base-category-attribute.md
+++ b/docs/schemas/components/base-category-attribute.md
@@ -1,3 +1,8 @@
+---
+seoTitle: base-category-attribute Component for Evo Schemas | Seequent Developer
+description: Review the base category attribute component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/base-category-attribute-1.0.0.md';
 

--- a/docs/schemas/components/base-continuous-attribute.md
+++ b/docs/schemas/components/base-continuous-attribute.md
@@ -1,3 +1,8 @@
+---
+seoTitle: base-continuous-attribute Component for Evo Schemas | Seequent Developer
+description: Review the base continuous attribute component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/base-continuous-attribute-1.1.0.md';
 

--- a/docs/schemas/components/base-object-properties.md
+++ b/docs/schemas/components/base-object-properties.md
@@ -1,3 +1,8 @@
+---
+seoTitle: base-object-properties Component for Evo Schemas | Seequent Developer
+description: Review the base object properties component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/base-object-properties-1.1.0.md';
 

--- a/docs/schemas/components/base-spatial-data-properties.md
+++ b/docs/schemas/components/base-spatial-data-properties.md
@@ -1,3 +1,8 @@
+---
+seoTitle: base-spatial-data-properties Component for Evo Schemas | Seequent Developer
+description: Review the base spatial data properties component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/base-spatial-data-properties-1.1.0.md';
 

--- a/docs/schemas/components/block-model-attribute.md
+++ b/docs/schemas/components/block-model-attribute.md
@@ -1,3 +1,8 @@
+---
+seoTitle: block-model-attribute Component for Evo Schemas | Seequent Developer
+description: Review the block model attribute component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/block-model-attribute-1.2.0.md';
 

--- a/docs/schemas/components/block-model-category-attribute.md
+++ b/docs/schemas/components/block-model-category-attribute.md
@@ -1,3 +1,8 @@
+---
+seoTitle: block-model-category-attribute Component for Evo Schemas | Seequent Developer
+description: Review the block model category attribute component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/block-model-category-attribute-1.1.0.md';
 

--- a/docs/schemas/components/block-model-flexible-structure.md
+++ b/docs/schemas/components/block-model-flexible-structure.md
@@ -1,3 +1,8 @@
+---
+seoTitle: block-model-flexible-structure Component for Evo Schemas | Seequent Developer
+description: Review the block model flexible structure component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/block-model-flexible-structure-1.0.0.md';
 

--- a/docs/schemas/components/block-model-fully-subblocked-structure.md
+++ b/docs/schemas/components/block-model-fully-subblocked-structure.md
@@ -1,3 +1,8 @@
+---
+seoTitle: block-model-fully-subblocked-structure Component for Evo Schemas | Seequent Developer
+description: Review the block model fully subblocked structure component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/block-model-fully-subblocked-structure-1.0.0.md';
 

--- a/docs/schemas/components/block-model-regular-structure.md
+++ b/docs/schemas/components/block-model-regular-structure.md
@@ -1,3 +1,8 @@
+---
+seoTitle: block-model-regular-structure Component for Evo Schemas | Seequent Developer
+description: Review the block model regular structure component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/block-model-regular-structure-1.0.0.md';
 

--- a/docs/schemas/components/block-model-variable-octree-structure.md
+++ b/docs/schemas/components/block-model-variable-octree-structure.md
@@ -1,3 +1,8 @@
+---
+seoTitle: block-model-variable-octree-structure Component for Evo Schemas | Seequent Developer
+description: Review the block model variable octree structure component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/block-model-variable-octree-structure-1.0.0.md';
 

--- a/docs/schemas/components/bool-attribute.md
+++ b/docs/schemas/components/bool-attribute.md
@@ -1,3 +1,8 @@
+---
+seoTitle: bool-attribute Component for Evo Schemas | Seequent Developer
+description: Review the bool attribute component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/bool-attribute-1.1.0.md';
 

--- a/docs/schemas/components/bool-time-series.md
+++ b/docs/schemas/components/bool-time-series.md
@@ -1,3 +1,8 @@
+---
+seoTitle: bool-time-series Component for Evo Schemas | Seequent Developer
+description: Review the bool time series component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/bool-time-series-1.1.0.md';
 

--- a/docs/schemas/components/bounding-box.md
+++ b/docs/schemas/components/bounding-box.md
@@ -1,3 +1,8 @@
+---
+seoTitle: bounding-box Component for Evo Schemas | Seequent Developer
+description: Review the bounding box component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/bounding-box-1.0.1.md';
 

--- a/docs/schemas/components/brep-container.md
+++ b/docs/schemas/components/brep-container.md
@@ -1,3 +1,8 @@
+---
+seoTitle: brep-container Component for Evo Schemas | Seequent Developer
+description: Review the brep container component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/brep-container-1.0.1.md';
 

--- a/docs/schemas/components/category-attribute-description.md
+++ b/docs/schemas/components/category-attribute-description.md
@@ -1,3 +1,8 @@
+---
+seoTitle: category-attribute-description Component for Evo Schemas | Seequent Developer
+description: Review the category attribute description component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/category-attribute-description-1.0.1.md';
 

--- a/docs/schemas/components/category-attribute.md
+++ b/docs/schemas/components/category-attribute.md
@@ -1,3 +1,8 @@
+---
+seoTitle: category-attribute Component for Evo Schemas | Seequent Developer
+description: Review the category attribute component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/category-attribute-1.1.0.md';
 

--- a/docs/schemas/components/category-data.md
+++ b/docs/schemas/components/category-data.md
@@ -1,3 +1,8 @@
+---
+seoTitle: category-data Component for Evo Schemas | Seequent Developer
+description: Review the category data component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/category-data-1.0.1.md';
 

--- a/docs/schemas/components/category-ensemble.md
+++ b/docs/schemas/components/category-ensemble.md
@@ -1,3 +1,8 @@
+---
+seoTitle: category-ensemble Component for Evo Schemas | Seequent Developer
+description: Review the category ensemble component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/category-ensemble-1.1.0.md';
 

--- a/docs/schemas/components/category-time-series.md
+++ b/docs/schemas/components/category-time-series.md
@@ -1,3 +1,8 @@
+---
+seoTitle: category-time-series Component for Evo Schemas | Seequent Developer
+description: Review the category time series component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/category-time-series-1.1.0.md';
 

--- a/docs/schemas/components/channel-attribute.md
+++ b/docs/schemas/components/channel-attribute.md
@@ -1,3 +1,8 @@
+---
+seoTitle: channel-attribute Component for Evo Schemas | Seequent Developer
+description: Review the channel attribute component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/channel-attribute-1.1.0.md';
 

--- a/docs/schemas/components/color-attribute.md
+++ b/docs/schemas/components/color-attribute.md
@@ -1,3 +1,8 @@
+---
+seoTitle: color-attribute Component for Evo Schemas | Seequent Developer
+description: Review the color attribute component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/color-attribute-1.1.0.md';
 

--- a/docs/schemas/components/continuous-attribute.md
+++ b/docs/schemas/components/continuous-attribute.md
@@ -1,3 +1,8 @@
+---
+seoTitle: continuous-attribute Component for Evo Schemas | Seequent Developer
+description: Review the continuous attribute component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/continuous-attribute-1.1.0.md';
 

--- a/docs/schemas/components/continuous-ensemble.md
+++ b/docs/schemas/components/continuous-ensemble.md
@@ -1,3 +1,8 @@
+---
+seoTitle: continuous-ensemble Component for Evo Schemas | Seequent Developer
+description: Review the continuous ensemble component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/continuous-ensemble-1.1.0.md';
 

--- a/docs/schemas/components/continuous-time-series.md
+++ b/docs/schemas/components/continuous-time-series.md
@@ -1,3 +1,8 @@
+---
+seoTitle: continuous-time-series Component for Evo Schemas | Seequent Developer
+description: Review the continuous time series component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/continuous-time-series-1.1.0.md';
 

--- a/docs/schemas/components/crs.md
+++ b/docs/schemas/components/crs.md
@@ -1,3 +1,8 @@
+---
+seoTitle: crs Component for Evo Schemas | Seequent Developer
+description: Review the CRS component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/crs-1.0.1.md';
 

--- a/docs/schemas/components/cumulative-distribution-function.md
+++ b/docs/schemas/components/cumulative-distribution-function.md
@@ -1,3 +1,8 @@
+---
+seoTitle: cumulative-distribution-function Component for Evo Schemas | Seequent Developer
+description: Review the cumulative distribution function component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/cumulative-distribution-function-1.0.1.md';
 

--- a/docs/schemas/components/data-table.md
+++ b/docs/schemas/components/data-table.md
@@ -1,3 +1,8 @@
+---
+seoTitle: data-table Component for Evo Schemas | Seequent Developer
+description: Review the data table component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/data-table-1.2.0.md';
 

--- a/docs/schemas/components/date-time-attribute.md
+++ b/docs/schemas/components/date-time-attribute.md
@@ -1,3 +1,8 @@
+---
+seoTitle: date-time-attribute Component for Evo Schemas | Seequent Developer
+description: Review the date time attribute component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/date-time-attribute-1.1.0.md';
 

--- a/docs/schemas/components/desurvey-method.md
+++ b/docs/schemas/components/desurvey-method.md
@@ -1,3 +1,8 @@
+---
+seoTitle: desurvey-method Component for Evo Schemas | Seequent Developer
+description: Review the desurvey method component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/desurvey-method-1.0.0.md';
 

--- a/docs/schemas/components/distance-table.md
+++ b/docs/schemas/components/distance-table.md
@@ -1,3 +1,8 @@
+---
+seoTitle: distance-table Component for Evo Schemas | Seequent Developer
+description: Review the distance table component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/distance-table-1.2.0.md';
 

--- a/docs/schemas/components/downhole-attributes.md
+++ b/docs/schemas/components/downhole-attributes.md
@@ -1,3 +1,8 @@
+---
+seoTitle: downhole-attributes Component for Evo Schemas | Seequent Developer
+description: Review the downhole attributes component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/downhole-attributes-1.0.0.md';
 

--- a/docs/schemas/components/downhole-direction-vector.md
+++ b/docs/schemas/components/downhole-direction-vector.md
@@ -1,3 +1,8 @@
+---
+seoTitle: downhole-direction-vector Component for Evo Schemas | Seequent Developer
+description: Review the downhole direction vector component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/downhole-direction-vector-1.0.0.md';
 

--- a/docs/schemas/components/ellipsoid.md
+++ b/docs/schemas/components/ellipsoid.md
@@ -1,3 +1,8 @@
+---
+seoTitle: ellipsoid Component for Evo Schemas | Seequent Developer
+description: Review the ellipsoid component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/ellipsoid-1.1.0.md';
 

--- a/docs/schemas/components/ellipsoids.md
+++ b/docs/schemas/components/ellipsoids.md
@@ -1,3 +1,8 @@
+---
+seoTitle: ellipsoids Component for Evo Schemas | Seequent Developer
+description: Review the ellipsoids component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/ellipsoids-1.0.1.md';
 

--- a/docs/schemas/components/embedded-line-geometry.md
+++ b/docs/schemas/components/embedded-line-geometry.md
@@ -1,3 +1,8 @@
+---
+seoTitle: embedded-line-geometry Component for Evo Schemas | Seequent Developer
+description: Review the embedded line geometry component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/embedded-line-geometry-1.0.0.md';
 

--- a/docs/schemas/components/embedded-mesh-object.md
+++ b/docs/schemas/components/embedded-mesh-object.md
@@ -1,3 +1,8 @@
+---
+seoTitle: embedded-mesh-object Component for Evo Schemas | Seequent Developer
+description: Review the embedded mesh object component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/embedded-mesh-object-1.0.0.md';
 

--- a/docs/schemas/components/embedded-polyline-object.md
+++ b/docs/schemas/components/embedded-polyline-object.md
@@ -1,3 +1,8 @@
+---
+seoTitle: embedded-polyline-object Component for Evo Schemas | Seequent Developer
+description: Review the embedded polyline object component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/embedded-polyline-object-1.0.0.md';
 

--- a/docs/schemas/components/embedded-triangulated-mesh.md
+++ b/docs/schemas/components/embedded-triangulated-mesh.md
@@ -1,3 +1,8 @@
+---
+seoTitle: embedded-triangulated-mesh Component for Evo Schemas | Seequent Developer
+description: Review the embedded triangulated mesh component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/embedded-triangulated-mesh-2.1.0.md';
 

--- a/docs/schemas/components/fiducial-description.md
+++ b/docs/schemas/components/fiducial-description.md
@@ -1,3 +1,8 @@
+---
+seoTitle: fiducial-description Component for Evo Schemas | Seequent Developer
+description: Review the fiducial description component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/fiducial-description-1.0.1.md';
 

--- a/docs/schemas/components/frequency-domain-electromagnetic-channel.md
+++ b/docs/schemas/components/frequency-domain-electromagnetic-channel.md
@@ -1,3 +1,8 @@
+---
+seoTitle: frequency-domain-electromagnetic-channel Component for Evo Schemas | Seequent Developer
+description: Review the frequency domain electromagnetic channel component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/frequency-domain-electromagnetic-channel-1.0.0.md';
 

--- a/docs/schemas/components/from-to.md
+++ b/docs/schemas/components/from-to.md
@@ -1,3 +1,8 @@
+---
+seoTitle: from-to Component for Evo Schemas | Seequent Developer
+description: Review the from to component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/from-to-1.0.1.md';
 

--- a/docs/schemas/components/geometry-composite.md
+++ b/docs/schemas/components/geometry-composite.md
@@ -1,3 +1,8 @@
+---
+seoTitle: geometry-composite Component for Evo Schemas | Seequent Developer
+description: Review the geometry composite component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/geometry-composite-1.0.1.md';
 

--- a/docs/schemas/components/geometry-part.md
+++ b/docs/schemas/components/geometry-part.md
@@ -1,3 +1,8 @@
+---
+seoTitle: geometry-part Component for Evo Schemas | Seequent Developer
+description: Review the geometry part component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/geometry-part-1.0.1.md';
 

--- a/docs/schemas/components/hexahedrons.md
+++ b/docs/schemas/components/hexahedrons.md
@@ -1,3 +1,8 @@
+---
+seoTitle: hexahedrons Component for Evo Schemas | Seequent Developer
+description: Review the hexahedrons component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/hexahedrons-1.2.0.md';
 

--- a/docs/schemas/components/hole-chunks.md
+++ b/docs/schemas/components/hole-chunks.md
@@ -1,3 +1,8 @@
+---
+seoTitle: hole-chunks Component for Evo Schemas | Seequent Developer
+description: Review the hole chunks component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/hole-chunks-1.0.0.md';
 

--- a/docs/schemas/components/hole-collars.md
+++ b/docs/schemas/components/hole-collars.md
@@ -1,3 +1,8 @@
+---
+seoTitle: hole-collars Component for Evo Schemas | Seequent Developer
+description: Review the hole collars component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/hole-collars-1.0.0.md';
 

--- a/docs/schemas/components/index.md
+++ b/docs/schemas/components/index.md
@@ -1,3 +1,8 @@
+---
+seoTitle: Component Evo Schemas for Geoscience Objects | Seequent Developer
+description: Explore Geoscience Objects components schemas for Seequent Evo, supporting consistent data structures and reliable workflows.
+---
+
 # Component schemas
 
 Components are reusable building blocks composed into [geoscience object schemas](../objects/index.md). They define shared structures such as coordinate systems, attributes, geometry primitives, and domain-specific data formats. Components are themselves built from [elements](../elements/index.md) — the lowest-level data primitives.

--- a/docs/schemas/components/indices-attribute.md
+++ b/docs/schemas/components/indices-attribute.md
@@ -1,3 +1,8 @@
+---
+seoTitle: indices-attribute Component for Evo Schemas | Seequent Developer
+description: Review the indices attribute component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/indices-attribute-1.1.0.md';
 

--- a/docs/schemas/components/integer-attribute.md
+++ b/docs/schemas/components/integer-attribute.md
@@ -1,3 +1,8 @@
+---
+seoTitle: integer-attribute Component for Evo Schemas | Seequent Developer
+description: Review the integer attribute component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/integer-attribute-1.1.0.md';
 

--- a/docs/schemas/components/interval-table.md
+++ b/docs/schemas/components/interval-table.md
@@ -1,3 +1,8 @@
+---
+seoTitle: interval-table Component for Evo Schemas | Seequent Developer
+description: Review the interval table component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/interval-table-1.2.0.md';
 

--- a/docs/schemas/components/intervals.md
+++ b/docs/schemas/components/intervals.md
@@ -1,3 +1,8 @@
+---
+seoTitle: intervals Component for Evo Schemas | Seequent Developer
+description: Review the intervals component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/intervals-1.0.1.md';
 

--- a/docs/schemas/components/lengths.md
+++ b/docs/schemas/components/lengths.md
@@ -1,3 +1,8 @@
+---
+seoTitle: lengths Component for Evo Schemas | Seequent Developer
+description: Review the lengths component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/lengths-1.0.1.md';
 

--- a/docs/schemas/components/lineage.md
+++ b/docs/schemas/components/lineage.md
@@ -1,3 +1,8 @@
+---
+seoTitle: lineage Component for Evo Schemas | Seequent Developer
+description: Review the lineage component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/lineage-1.0.0.md';
 import Alert from '@mui/material/Alert';

--- a/docs/schemas/components/lineation-data.md
+++ b/docs/schemas/components/lineation-data.md
@@ -1,3 +1,8 @@
+---
+seoTitle: lineation-data Component for Evo Schemas | Seequent Developer
+description: Review the lineation data component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/lineation-data-1.0.1.md';
 

--- a/docs/schemas/components/lines-2d-indices.md
+++ b/docs/schemas/components/lines-2d-indices.md
@@ -1,3 +1,8 @@
+---
+seoTitle: lines-2d-indices Component for Evo Schemas | Seequent Developer
+description: Review the lines 2d indices component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/lines-2d-indices-1.0.1.md';
 

--- a/docs/schemas/components/lines-3d-indices.md
+++ b/docs/schemas/components/lines-3d-indices.md
@@ -1,3 +1,8 @@
+---
+seoTitle: lines-3d-indices Component for Evo Schemas | Seequent Developer
+description: Review the lines 3d indices component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/lines-3d-indices-1.0.1.md';
 

--- a/docs/schemas/components/locations.md
+++ b/docs/schemas/components/locations.md
@@ -1,3 +1,8 @@
+---
+seoTitle: locations Component for Evo Schemas | Seequent Developer
+description: Review the locations component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/locations-1.0.1.md';
 

--- a/docs/schemas/components/material.md
+++ b/docs/schemas/components/material.md
@@ -1,3 +1,8 @@
+---
+seoTitle: material Component for Evo Schemas | Seequent Developer
+description: Review the material component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/material-1.0.1.md';
 

--- a/docs/schemas/components/mesh-quality.md
+++ b/docs/schemas/components/mesh-quality.md
@@ -1,3 +1,8 @@
+---
+seoTitle: mesh-quality Component for Evo Schemas | Seequent Developer
+description: Review the mesh quality component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/mesh-quality-1.0.1.md';
 

--- a/docs/schemas/components/nan-categorical.md
+++ b/docs/schemas/components/nan-categorical.md
@@ -1,3 +1,8 @@
+---
+seoTitle: nan-categorical Component for Evo Schemas | Seequent Developer
+description: Review the nan categorical component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/nan-categorical-1.0.1.md';
 

--- a/docs/schemas/components/nan-continuous.md
+++ b/docs/schemas/components/nan-continuous.md
@@ -1,3 +1,8 @@
+---
+seoTitle: nan-continuous Component for Evo Schemas | Seequent Developer
+description: Review the nan continuous component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/nan-continuous-1.0.1.md';
 

--- a/docs/schemas/components/one-of-attribute.md
+++ b/docs/schemas/components/one-of-attribute.md
@@ -1,3 +1,8 @@
+---
+seoTitle: one-of-attribute Component for Evo Schemas | Seequent Developer
+description: Review the one of attribute component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/one-of-attribute-1.2.0.md';
 

--- a/docs/schemas/components/planar-data.md
+++ b/docs/schemas/components/planar-data.md
@@ -1,3 +1,8 @@
+---
+seoTitle: planar-data Component for Evo Schemas | Seequent Developer
+description: Review the planar data component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/planar-data-1.0.1.md';
 

--- a/docs/schemas/components/polyline-2d.md
+++ b/docs/schemas/components/polyline-2d.md
@@ -1,3 +1,8 @@
+---
+seoTitle: polyline-2d Component for Evo Schemas | Seequent Developer
+description: Review the polyline 2d component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/polyline-2d-1.0.1.md';
 

--- a/docs/schemas/components/polyline-3d.md
+++ b/docs/schemas/components/polyline-3d.md
@@ -1,3 +1,8 @@
+---
+seoTitle: polyline-3d Component for Evo Schemas | Seequent Developer
+description: Review the polyline 3d component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/polyline-3d-1.0.1.md';
 

--- a/docs/schemas/components/quadrilaterals.md
+++ b/docs/schemas/components/quadrilaterals.md
@@ -1,3 +1,8 @@
+---
+seoTitle: quadrilaterals Component for Evo Schemas | Seequent Developer
+description: Review the quadrilaterals component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/quadrilaterals-1.2.0.md';
 

--- a/docs/schemas/components/relative-lineation-data-table.md
+++ b/docs/schemas/components/relative-lineation-data-table.md
@@ -1,3 +1,8 @@
+---
+seoTitle: relative-lineation-data-table Component for Evo Schemas | Seequent Developer
+description: Review the relative lineation data table component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/relative-lineation-data-table-1.2.0.md';
 

--- a/docs/schemas/components/relative-planar-data-table.md
+++ b/docs/schemas/components/relative-planar-data-table.md
@@ -1,3 +1,8 @@
+---
+seoTitle: relative-planar-data-table Component for Evo Schemas | Seequent Developer
+description: Review the relative planar data table component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/relative-planar-data-table-1.2.0.md';
 

--- a/docs/schemas/components/resistivity-ip-dcip-survey-properties.md
+++ b/docs/schemas/components/resistivity-ip-dcip-survey-properties.md
@@ -1,3 +1,8 @@
+---
+seoTitle: resistivity-ip-dcip-survey-properties Component for Evo Schemas | Seequent Developer
+description: Review the resistivity IP DCIP survey properties component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/resistivity-ip-dcip-survey-properties-1.0.0.md';
 

--- a/docs/schemas/components/resistivity-ip-line.md
+++ b/docs/schemas/components/resistivity-ip-line.md
@@ -1,3 +1,8 @@
+---
+seoTitle: resistivity-ip-line Component for Evo Schemas | Seequent Developer
+description: Review the resistivity IP line component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/resistivity-ip-line-1.1.0.md';
 

--- a/docs/schemas/components/resistivity-ip-phaseip-survey-properties.md
+++ b/docs/schemas/components/resistivity-ip-phaseip-survey-properties.md
@@ -1,3 +1,8 @@
+---
+seoTitle: resistivity-ip-phaseip-survey-properties Component for Evo Schemas | Seequent Developer
+description: Review the resistivity IP phaseip survey properties component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/resistivity-ip-phaseip-survey-properties-1.0.0.md';
 

--- a/docs/schemas/components/resistivity-ip-pldp-configuration-properties.md
+++ b/docs/schemas/components/resistivity-ip-pldp-configuration-properties.md
@@ -1,3 +1,8 @@
+---
+seoTitle: resistivity-ip-pldp-configuration-properties Component for Evo Schemas | Seequent Developer
+description: Review the resistivity IP PLDP configuration properties component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/resistivity-ip-pldp-configuration-properties-1.0.0.md';
 

--- a/docs/schemas/components/resistivity-ip-plpl-configuration-properties.md
+++ b/docs/schemas/components/resistivity-ip-plpl-configuration-properties.md
@@ -1,3 +1,8 @@
+---
+seoTitle: resistivity-ip-plpl-configuration-properties Component for Evo Schemas | Seequent Developer
+description: Review the resistivity IP PLPL configuration properties component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/resistivity-ip-plpl-configuration-properties-1.0.0.md';
 

--- a/docs/schemas/components/resistivity-ip-sip-survey-properties.md
+++ b/docs/schemas/components/resistivity-ip-sip-survey-properties.md
@@ -1,3 +1,8 @@
+---
+seoTitle: resistivity-ip-sip-survey-properties Component for Evo Schemas | Seequent Developer
+description: Review the resistivity IP SIP survey properties component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/resistivity-ip-sip-survey-properties-1.0.0.md';
 

--- a/docs/schemas/components/rotation.md
+++ b/docs/schemas/components/rotation.md
@@ -1,3 +1,8 @@
+---
+seoTitle: rotation Component for Evo Schemas | Seequent Developer
+description: Review the rotation component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/rotation-1.1.0.md';
 

--- a/docs/schemas/components/segments.md
+++ b/docs/schemas/components/segments.md
@@ -1,3 +1,8 @@
+---
+seoTitle: segments Component for Evo Schemas | Seequent Developer
+description: Review the segments component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/segments-1.2.0.md';
 

--- a/docs/schemas/components/string-attribute.md
+++ b/docs/schemas/components/string-attribute.md
@@ -1,3 +1,8 @@
+---
+seoTitle: string-attribute Component for Evo Schemas | Seequent Developer
+description: Review the string attribute component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/string-attribute-1.1.0.md';
 

--- a/docs/schemas/components/surface-mesh.md
+++ b/docs/schemas/components/surface-mesh.md
@@ -1,3 +1,8 @@
+---
+seoTitle: surface-mesh Component for Evo Schemas | Seequent Developer
+description: Review the surface mesh component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/surface-mesh-1.0.1.md';
 

--- a/docs/schemas/components/survey-attribute-definition.md
+++ b/docs/schemas/components/survey-attribute-definition.md
@@ -1,3 +1,8 @@
+---
+seoTitle: survey-attribute-definition Component for Evo Schemas | Seequent Developer
+description: Review the survey attribute definition component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/survey-attribute-definition-1.0.1.md';
 

--- a/docs/schemas/components/survey-attribute.md
+++ b/docs/schemas/components/survey-attribute.md
@@ -1,3 +1,8 @@
+---
+seoTitle: survey-attribute Component for Evo Schemas | Seequent Developer
+description: Review the survey attribute component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/survey-attribute-1.0.1.md';
 

--- a/docs/schemas/components/survey-collection.md
+++ b/docs/schemas/components/survey-collection.md
@@ -1,3 +1,8 @@
+---
+seoTitle: survey-collection Component for Evo Schemas | Seequent Developer
+description: Review the survey collection component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/survey-collection-1.0.1.md';
 

--- a/docs/schemas/components/survey-line.md
+++ b/docs/schemas/components/survey-line.md
@@ -1,3 +1,8 @@
+---
+seoTitle: survey-line Component for Evo Schemas | Seequent Developer
+description: Review the survey line component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/survey-line-1.1.0.md';
 

--- a/docs/schemas/components/tetrahedra.md
+++ b/docs/schemas/components/tetrahedra.md
@@ -1,3 +1,8 @@
+---
+seoTitle: tetrahedra Component for Evo Schemas | Seequent Developer
+description: Review the tetrahedra component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/tetrahedra-1.2.0.md';
 

--- a/docs/schemas/components/time-domain-electromagnetic-channel.md
+++ b/docs/schemas/components/time-domain-electromagnetic-channel.md
@@ -1,3 +1,8 @@
+---
+seoTitle: time-domain-electromagnetic-channel Component for Evo Schemas | Seequent Developer
+description: Review the time domain electromagnetic channel component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/time-domain-electromagnetic-channel-1.0.0.md';
 

--- a/docs/schemas/components/time-step-attribute.md
+++ b/docs/schemas/components/time-step-attribute.md
@@ -1,3 +1,8 @@
+---
+seoTitle: time-step-attribute Component for Evo Schemas | Seequent Developer
+description: Review the time step attribute component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/time-step-attribute-1.1.0.md';
 

--- a/docs/schemas/components/time-step-continuous-attribute.md
+++ b/docs/schemas/components/time-step-continuous-attribute.md
@@ -1,3 +1,8 @@
+---
+seoTitle: time-step-continuous-attribute Component for Evo Schemas | Seequent Developer
+description: Review the time step continuous attribute component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/time-step-continuous-attribute-1.1.0.md';
 

--- a/docs/schemas/components/time-step-date-time-attribute.md
+++ b/docs/schemas/components/time-step-date-time-attribute.md
@@ -1,3 +1,8 @@
+---
+seoTitle: time-step-date-time-attribute Component for Evo Schemas | Seequent Developer
+description: Review the time step date time attribute component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/time-step-date-time-attribute-1.1.0.md';
 

--- a/docs/schemas/components/triangles.md
+++ b/docs/schemas/components/triangles.md
@@ -1,3 +1,8 @@
+---
+seoTitle: triangles Component for Evo Schemas | Seequent Developer
+description: Review the triangles component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/triangles-1.2.0.md';
 

--- a/docs/schemas/components/unstructured-grid-geometry.md
+++ b/docs/schemas/components/unstructured-grid-geometry.md
@@ -1,3 +1,8 @@
+---
+seoTitle: unstructured-grid-geometry Component for Evo Schemas | Seequent Developer
+description: Review the unstructured grid geometry component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/unstructured-grid-geometry-1.2.0.md';
 

--- a/docs/schemas/components/variogram-cubic-structure.md
+++ b/docs/schemas/components/variogram-cubic-structure.md
@@ -1,3 +1,8 @@
+---
+seoTitle: variogram-cubic-structure Component for Evo Schemas | Seequent Developer
+description: Review the variogram cubic structure component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/variogram-cubic-structure-1.1.0.md';
 

--- a/docs/schemas/components/variogram-exponential-structure.md
+++ b/docs/schemas/components/variogram-exponential-structure.md
@@ -1,3 +1,8 @@
+---
+seoTitle: variogram-exponential-structure Component for Evo Schemas | Seequent Developer
+description: Review the variogram exponential structure component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/variogram-exponential-structure-1.1.0.md';
 

--- a/docs/schemas/components/variogram-gaussian-structure.md
+++ b/docs/schemas/components/variogram-gaussian-structure.md
@@ -1,3 +1,8 @@
+---
+seoTitle: variogram-gaussian-structure Component for Evo Schemas | Seequent Developer
+description: Review the variogram gaussian structure component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/variogram-gaussian-structure-1.1.0.md';
 

--- a/docs/schemas/components/variogram-generalisedcauchy-structure.md
+++ b/docs/schemas/components/variogram-generalisedcauchy-structure.md
@@ -1,3 +1,8 @@
+---
+seoTitle: variogram-generalisedcauchy-structure Component for Evo Schemas | Seequent Developer
+description: Review the variogram generalisedcauchy structure component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/variogram-generalisedcauchy-structure-1.1.0.md';
 

--- a/docs/schemas/components/variogram-linear-structure.md
+++ b/docs/schemas/components/variogram-linear-structure.md
@@ -1,3 +1,8 @@
+---
+seoTitle: variogram-linear-structure Component for Evo Schemas | Seequent Developer
+description: Review the variogram linear structure component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/variogram-linear-structure-1.1.0.md';
 

--- a/docs/schemas/components/variogram-spherical-structure.md
+++ b/docs/schemas/components/variogram-spherical-structure.md
@@ -1,3 +1,8 @@
+---
+seoTitle: variogram-spherical-structure Component for Evo Schemas | Seequent Developer
+description: Review the variogram spherical structure component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/variogram-spherical-structure-1.1.0.md';
 

--- a/docs/schemas/components/variogram-spheroidal-structure.md
+++ b/docs/schemas/components/variogram-spheroidal-structure.md
@@ -1,3 +1,8 @@
+---
+seoTitle: variogram-spheroidal-structure Component for Evo Schemas | Seequent Developer
+description: Review the variogram spheroidal structure component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/variogram-spheroidal-structure-1.1.0.md';
 

--- a/docs/schemas/components/vector-attribute.md
+++ b/docs/schemas/components/vector-attribute.md
@@ -1,3 +1,8 @@
+---
+seoTitle: vector-attribute Component for Evo Schemas | Seequent Developer
+description: Review the vector attribute component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/vector-attribute-1.0.0.md';
 

--- a/docs/schemas/components/vertices-2d.md
+++ b/docs/schemas/components/vertices-2d.md
@@ -1,3 +1,8 @@
+---
+seoTitle: vertices-2d Component for Evo Schemas | Seequent Developer
+description: Review the vertices 2d component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/vertices-2d-1.0.1.md';
 

--- a/docs/schemas/components/vertices-3d.md
+++ b/docs/schemas/components/vertices-3d.md
@@ -1,3 +1,8 @@
+---
+seoTitle: vertices-3d Component for Evo Schemas | Seequent Developer
+description: Review the vertices 3d component schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/components/vertices-3d-1.0.1.md';
 

--- a/docs/schemas/elements/binary-blob.md
+++ b/docs/schemas/elements/binary-blob.md
@@ -1,3 +1,8 @@
+---
+seoTitle: binary-blob Element for Evo Schemas | Seequent Developer
+description: Review the binary blob element schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/elements/binary-blob-1.0.1.md';
 

--- a/docs/schemas/elements/bool-array-1.md
+++ b/docs/schemas/elements/bool-array-1.md
@@ -1,3 +1,8 @@
+---
+seoTitle: bool-array-1 Element for Evo Schemas | Seequent Developer
+description: Review the bool array 1 element schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/elements/bool-array-1-1.0.1.md';
 

--- a/docs/schemas/elements/bool-array-md.md
+++ b/docs/schemas/elements/bool-array-md.md
@@ -1,3 +1,8 @@
+---
+seoTitle: bool-array-md Element for Evo Schemas | Seequent Developer
+description: Review the bool array md element schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/elements/bool-array-md-1.0.1.md';
 

--- a/docs/schemas/elements/color-array.md
+++ b/docs/schemas/elements/color-array.md
@@ -1,3 +1,8 @@
+---
+seoTitle: color-array Element for Evo Schemas | Seequent Developer
+description: Review the color array element schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/elements/color-array-1.0.1.md';
 

--- a/docs/schemas/elements/color.md
+++ b/docs/schemas/elements/color.md
@@ -1,3 +1,8 @@
+---
+seoTitle: color Element for Evo Schemas | Seequent Developer
+description: Review the color element schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/elements/color-1.0.1.md';
 

--- a/docs/schemas/elements/coordinates-3d.md
+++ b/docs/schemas/elements/coordinates-3d.md
@@ -1,3 +1,8 @@
+---
+seoTitle: coordinates-3d Element for Evo Schemas | Seequent Developer
+description: Review the coordinates 3d element schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/elements/coordinates-3d-1.0.0.md';
 

--- a/docs/schemas/elements/date-time-array.md
+++ b/docs/schemas/elements/date-time-array.md
@@ -1,3 +1,8 @@
+---
+seoTitle: date-time-array Element for Evo Schemas | Seequent Developer
+description: Review the date time array element schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/elements/date-time-array-1.0.1.md';
 

--- a/docs/schemas/elements/float-array-1.md
+++ b/docs/schemas/elements/float-array-1.md
@@ -1,3 +1,8 @@
+---
+seoTitle: float-array-1 Element for Evo Schemas | Seequent Developer
+description: Review the float array 1 element schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/elements/float-array-1-1.0.1.md';
 

--- a/docs/schemas/elements/float-array-2.md
+++ b/docs/schemas/elements/float-array-2.md
@@ -1,3 +1,8 @@
+---
+seoTitle: float-array-2 Element for Evo Schemas | Seequent Developer
+description: Review the float array 2 element schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/elements/float-array-2-1.0.1.md';
 

--- a/docs/schemas/elements/float-array-3.md
+++ b/docs/schemas/elements/float-array-3.md
@@ -1,3 +1,8 @@
+---
+seoTitle: float-array-3 Element for Evo Schemas | Seequent Developer
+description: Review the float array 3 element schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/elements/float-array-3-1.0.1.md';
 

--- a/docs/schemas/elements/float-array-6.md
+++ b/docs/schemas/elements/float-array-6.md
@@ -1,3 +1,8 @@
+---
+seoTitle: float-array-6 Element for Evo Schemas | Seequent Developer
+description: Review the float array 6 element schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/elements/float-array-6-1.0.1.md';
 

--- a/docs/schemas/elements/float-array-md.md
+++ b/docs/schemas/elements/float-array-md.md
@@ -1,3 +1,8 @@
+---
+seoTitle: float-array-md Element for Evo Schemas | Seequent Developer
+description: Review the float array md element schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/elements/float-array-md-1.0.1.md';
 

--- a/docs/schemas/elements/index-array-1.md
+++ b/docs/schemas/elements/index-array-1.md
@@ -1,3 +1,8 @@
+---
+seoTitle: index-array-1 Element for Evo Schemas | Seequent Developer
+description: Review the index array 1 element schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/elements/index-array-1-1.0.1.md';
 

--- a/docs/schemas/elements/index-array-2.md
+++ b/docs/schemas/elements/index-array-2.md
@@ -1,3 +1,8 @@
+---
+seoTitle: index-array-2 Element for Evo Schemas | Seequent Developer
+description: Review the index array 2 element schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/elements/index-array-2-1.0.1.md';
 

--- a/docs/schemas/elements/index-array-3.md
+++ b/docs/schemas/elements/index-array-3.md
@@ -1,3 +1,8 @@
+---
+seoTitle: index-array-3 Element for Evo Schemas | Seequent Developer
+description: Review the index array 3 element schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/elements/index-array-3-1.0.1.md';
 

--- a/docs/schemas/elements/index-array-4.md
+++ b/docs/schemas/elements/index-array-4.md
@@ -1,3 +1,8 @@
+---
+seoTitle: index-array-4 Element for Evo Schemas | Seequent Developer
+description: Review the index array 4 element schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/elements/index-array-4-1.0.1.md';
 

--- a/docs/schemas/elements/index-array-8.md
+++ b/docs/schemas/elements/index-array-8.md
@@ -1,3 +1,8 @@
+---
+seoTitle: index-array-8 Element for Evo Schemas | Seequent Developer
+description: Review the index array 8 element schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/elements/index-array-8-1.0.1.md';
 

--- a/docs/schemas/elements/index.md
+++ b/docs/schemas/elements/index.md
@@ -1,3 +1,8 @@
+---
+seoTitle: Element Evo Schemas for Geoscience Objects | Seequent Developer
+description: Explore Geoscience Objects elements schemas for Seequent Evo, supporting consistent data structures and reliable workflows.
+---
+
 # Element schemas
 
 Elements are the lowest-level building blocks in the schema hierarchy — primitive data types that [components](../components/index.md) compose into higher-order structures. They define binary array formats, colour values, spatial coordinates, lookup tables, and the unit system.

--- a/docs/schemas/elements/integer-array-1.md
+++ b/docs/schemas/elements/integer-array-1.md
@@ -1,3 +1,8 @@
+---
+seoTitle: integer-array-1 Element for Evo Schemas | Seequent Developer
+description: Review the integer array 1 element schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/elements/integer-array-1-1.0.1.md';
 

--- a/docs/schemas/elements/integer-array-2.md
+++ b/docs/schemas/elements/integer-array-2.md
@@ -1,3 +1,8 @@
+---
+seoTitle: integer-array-2 Element for Evo Schemas | Seequent Developer
+description: Review the integer array 2 element schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 
 # integer-array-2

--- a/docs/schemas/elements/integer-array-3.md
+++ b/docs/schemas/elements/integer-array-3.md
@@ -1,3 +1,8 @@
+---
+seoTitle: integer-array-3 Element for Evo Schemas | Seequent Developer
+description: Review the integer array 3 element schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 
 # integer-array-3

--- a/docs/schemas/elements/integer-array-md.md
+++ b/docs/schemas/elements/integer-array-md.md
@@ -1,3 +1,8 @@
+---
+seoTitle: integer-array-md Element for Evo Schemas | Seequent Developer
+description: Review the integer array md element schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/elements/integer-array-md-1.0.1.md';
 

--- a/docs/schemas/elements/lookup-table.md
+++ b/docs/schemas/elements/lookup-table.md
@@ -1,3 +1,8 @@
+---
+seoTitle: lookup-table Element for Evo Schemas | Seequent Developer
+description: Review the lookup table element schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/elements/lookup-table-1.0.1.md';
 

--- a/docs/schemas/elements/reversible-index.md
+++ b/docs/schemas/elements/reversible-index.md
@@ -1,3 +1,8 @@
+---
+seoTitle: reversible-index Element for Evo Schemas | Seequent Developer
+description: Review the reversible index element schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/elements/reversible-index-1.0.0.md';
 

--- a/docs/schemas/elements/string-array.md
+++ b/docs/schemas/elements/string-array.md
@@ -1,3 +1,8 @@
+---
+seoTitle: string-array Element for Evo Schemas | Seequent Developer
+description: Review the string array element schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/elements/string-array-1.0.1.md';
 

--- a/docs/schemas/elements/unit.md
+++ b/docs/schemas/elements/unit.md
@@ -1,3 +1,8 @@
+---
+seoTitle: unit Element for Evo Schemas | Seequent Developer
+description: Review the unit element schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import SchemaUri from '@theme/SchemaUri';
 
 # unit

--- a/docs/schemas/index.md
+++ b/docs/schemas/index.md
@@ -1,3 +1,8 @@
+---
+seoTitle: Schemas for Geoscience Objects Data Structures | Seequent Developer
+description: Explore Geoscience Objects schemas for Seequent Evo, with resources for consistent, trustworthy data structures and custom workflows.
+---
+
 # Evo schemas
 
 Geoscience object schemas define the data structures used in the Evo platform. The schema hierarchy is organised into three tiers — objects, components, and elements — each documented in its own section below.

--- a/docs/schemas/objects/design-geometry.md
+++ b/docs/schemas/objects/design-geometry.md
@@ -1,3 +1,8 @@
+---
+seoTitle: design-geometry Object for Evo Schemas | Seequent Developer
+description: Review the design geometry object schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import OverlineWithVersion from '@theme/OverlineWithVersion';
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/objects/design-geometry-1.1.0.md';

--- a/docs/schemas/objects/downhole-collection.md
+++ b/docs/schemas/objects/downhole-collection.md
@@ -1,3 +1,8 @@
+---
+seoTitle: downhole-collection Object for Evo Schemas | Seequent Developer
+description: Review the downhole collection object schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import OverlineWithVersion from '@theme/OverlineWithVersion';
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/objects/downhole-collection-1.3.0.md';

--- a/docs/schemas/objects/downhole-intervals.md
+++ b/docs/schemas/objects/downhole-intervals.md
@@ -1,3 +1,8 @@
+---
+seoTitle: downhole-intervals Object for Evo Schemas | Seequent Developer
+description: Review the downhole intervals object schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import OverlineWithVersion from '@theme/OverlineWithVersion';
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/objects/downhole-intervals-1.3.0.md';

--- a/docs/schemas/objects/drilling-campaign.md
+++ b/docs/schemas/objects/drilling-campaign.md
@@ -1,3 +1,8 @@
+---
+seoTitle: drilling-campaign Object for Evo Schemas | Seequent Developer
+description: Review the drilling campaign object schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import OverlineWithVersion from '@theme/OverlineWithVersion';
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/objects/drilling-campaign-1.0.0.md';

--- a/docs/schemas/objects/experimental-variogram.md
+++ b/docs/schemas/objects/experimental-variogram.md
@@ -1,3 +1,8 @@
+---
+seoTitle: experimental-variogram Object for Evo Schemas | Seequent Developer
+description: Review the experimental variogram object schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import OverlineWithVersion from '@theme/OverlineWithVersion';
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/objects/experimental-variogram-1.0.0.md';

--- a/docs/schemas/objects/frequency-domain-electromagnetic.md
+++ b/docs/schemas/objects/frequency-domain-electromagnetic.md
@@ -1,3 +1,8 @@
+---
+seoTitle: frequency-domain-electromagnetic Object for Evo Schemas | Seequent Developer
+description: Review the frequency domain electromagnetic object schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import OverlineWithVersion from '@theme/OverlineWithVersion';
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/objects/frequency-domain-electromagnetic-1.1.0.md';

--- a/docs/schemas/objects/geological-model-meshes.md
+++ b/docs/schemas/objects/geological-model-meshes.md
@@ -1,3 +1,8 @@
+---
+seoTitle: geological-model-meshes Object for Evo Schemas | Seequent Developer
+description: Review the geological model meshes object schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import OverlineWithVersion from '@theme/OverlineWithVersion';
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/objects/geological-model-meshes-2.2.0.md';

--- a/docs/schemas/objects/geological-sections.md
+++ b/docs/schemas/objects/geological-sections.md
@@ -1,3 +1,8 @@
+---
+seoTitle: geological-sections Object for Evo Schemas | Seequent Developer
+description: Review the geological sections object schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import OverlineWithVersion from '@theme/OverlineWithVersion';
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/objects/geological-sections-1.2.0.md';

--- a/docs/schemas/objects/geophysical-records-1d.md
+++ b/docs/schemas/objects/geophysical-records-1d.md
@@ -1,3 +1,8 @@
+---
+seoTitle: geophysical-records-1d Object for Evo Schemas | Seequent Developer
+description: Review the geophysical records 1d object schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import OverlineWithVersion from '@theme/OverlineWithVersion';
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/objects/geophysical-records-1d-1.3.0.md';

--- a/docs/schemas/objects/global-ellipsoid.md
+++ b/docs/schemas/objects/global-ellipsoid.md
@@ -1,3 +1,8 @@
+---
+seoTitle: global-ellipsoid Object for Evo Schemas | Seequent Developer
+description: Review the global ellipsoid object schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import OverlineWithVersion from '@theme/OverlineWithVersion';
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/objects/global-ellipsoid-1.2.0.md';

--- a/docs/schemas/objects/index.md
+++ b/docs/schemas/objects/index.md
@@ -1,3 +1,8 @@
+---
+seoTitle: Geoscience Object Schemas, Evo Data Structures | Seequent Developer
+description: Explore Geoscience Objects objects schemas for Seequent Evo, supporting consistent data structures and reliable workflows.
+---
+
 # Geoscience object schemas
 
 Object schemas are the top-level data structures in the schema hierarchy. Each object composes reusable [components](../components/index.md), which are in turn built from primitive [elements](../elements/index.md).

--- a/docs/schemas/objects/line-segments.md
+++ b/docs/schemas/objects/line-segments.md
@@ -1,3 +1,8 @@
+---
+seoTitle: line-segments Object for Evo Schemas | Seequent Developer
+description: Review the line segments object schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import OverlineWithVersion from '@theme/OverlineWithVersion';
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/objects/line-segments-2.2.0.md';

--- a/docs/schemas/objects/lineations-data-pointset.md
+++ b/docs/schemas/objects/lineations-data-pointset.md
@@ -1,3 +1,8 @@
+---
+seoTitle: lineations-data-pointset Object for Evo Schemas | Seequent Developer
+description: Review the lineations data pointset object schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import OverlineWithVersion from '@theme/OverlineWithVersion';
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/objects/lineations-data-pointset-1.3.0.md';

--- a/docs/schemas/objects/local-ellipsoids.md
+++ b/docs/schemas/objects/local-ellipsoids.md
@@ -1,3 +1,8 @@
+---
+seoTitle: local-ellipsoids Object for Evo Schemas | Seequent Developer
+description: Review the local ellipsoids object schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import OverlineWithVersion from '@theme/OverlineWithVersion';
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/objects/local-ellipsoids-1.3.0.md';

--- a/docs/schemas/objects/non-parametric-continuous-cumulative-distribution.md
+++ b/docs/schemas/objects/non-parametric-continuous-cumulative-distribution.md
@@ -1,3 +1,8 @@
+---
+seoTitle: non-parametric-continuous-cumulative-distribution Object for Evo Schemas | Seequent Developer
+description: Review the non parametric continuous cumulative distribution object schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import OverlineWithVersion from '@theme/OverlineWithVersion';
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/objects/non-parametric-continuous-cumulative-distribution-1.2.0.md';

--- a/docs/schemas/objects/planar-data-pointset.md
+++ b/docs/schemas/objects/planar-data-pointset.md
@@ -1,3 +1,8 @@
+---
+seoTitle: planar-data-pointset Object for Evo Schemas | Seequent Developer
+description: Review the planar data pointset object schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import OverlineWithVersion from '@theme/OverlineWithVersion';
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/objects/planar-data-pointset-1.3.0.md';

--- a/docs/schemas/objects/pointset.md
+++ b/docs/schemas/objects/pointset.md
@@ -1,3 +1,8 @@
+---
+seoTitle: pointset Object for Evo Schemas | Seequent Developer
+description: Review the pointset object schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import OverlineWithVersion from '@theme/OverlineWithVersion';
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/objects/pointset-1.3.0.md';

--- a/docs/schemas/objects/regular-2d-grid.md
+++ b/docs/schemas/objects/regular-2d-grid.md
@@ -1,3 +1,8 @@
+---
+seoTitle: regular-2d-grid Object for Evo Schemas | Seequent Developer
+description: Review the regular 2d grid object schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import OverlineWithVersion from '@theme/OverlineWithVersion';
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/objects/regular-2d-grid-1.3.0.md';

--- a/docs/schemas/objects/regular-3d-grid.md
+++ b/docs/schemas/objects/regular-3d-grid.md
@@ -1,3 +1,8 @@
+---
+seoTitle: regular-3d-grid Object for Evo Schemas | Seequent Developer
+description: Review the regular 3d grid object schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import OverlineWithVersion from '@theme/OverlineWithVersion';
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/objects/regular-3d-grid-1.3.0.md';

--- a/docs/schemas/objects/regular-masked-3d-grid.md
+++ b/docs/schemas/objects/regular-masked-3d-grid.md
@@ -1,3 +1,8 @@
+---
+seoTitle: regular-masked-3d-grid Object for Evo Schemas | Seequent Developer
+description: Review the regular masked 3d grid object schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import OverlineWithVersion from '@theme/OverlineWithVersion';
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/objects/regular-masked-3d-grid-1.3.0.md';

--- a/docs/schemas/objects/resistivity-ip.md
+++ b/docs/schemas/objects/resistivity-ip.md
@@ -1,3 +1,8 @@
+---
+seoTitle: resistivity-ip Object for Evo Schemas | Seequent Developer
+description: Review the resistivity IP object schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import OverlineWithVersion from '@theme/OverlineWithVersion';
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/objects/resistivity-ip-1.1.0.md';

--- a/docs/schemas/objects/tensor-2d-grid.md
+++ b/docs/schemas/objects/tensor-2d-grid.md
@@ -1,3 +1,8 @@
+---
+seoTitle: tensor-2d-grid Object for Evo Schemas | Seequent Developer
+description: Review the tensor 2d grid object schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import OverlineWithVersion from '@theme/OverlineWithVersion';
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/objects/tensor-2d-grid-1.3.0.md';

--- a/docs/schemas/objects/tensor-3d-grid.md
+++ b/docs/schemas/objects/tensor-3d-grid.md
@@ -1,3 +1,8 @@
+---
+seoTitle: tensor-3d-grid Object for Evo Schemas | Seequent Developer
+description: Review the tensor 3d grid object schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import OverlineWithVersion from '@theme/OverlineWithVersion';
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/objects/tensor-3d-grid-1.3.0.md';

--- a/docs/schemas/objects/time-domain-electromagnetic.md
+++ b/docs/schemas/objects/time-domain-electromagnetic.md
@@ -1,3 +1,8 @@
+---
+seoTitle: time-domain-electromagnetic Object for Evo Schemas | Seequent Developer
+description: Review the time domain electromagnetic object schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import OverlineWithVersion from '@theme/OverlineWithVersion';
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/objects/time-domain-electromagnetic-1.1.0.md';

--- a/docs/schemas/objects/triangle-mesh.md
+++ b/docs/schemas/objects/triangle-mesh.md
@@ -1,3 +1,8 @@
+---
+seoTitle: triangle-mesh Object for Evo Schemas | Seequent Developer
+description: Review the triangle mesh object schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import OverlineWithVersion from '@theme/OverlineWithVersion';
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/objects/triangle-mesh-2.3.0.md';

--- a/docs/schemas/objects/unstructured-grid.md
+++ b/docs/schemas/objects/unstructured-grid.md
@@ -1,3 +1,8 @@
+---
+seoTitle: unstructured-grid Object for Evo Schemas | Seequent Developer
+description: Review the unstructured grid object schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import OverlineWithVersion from '@theme/OverlineWithVersion';
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/objects/unstructured-grid-1.3.0.md';

--- a/docs/schemas/objects/unstructured-hex-grid.md
+++ b/docs/schemas/objects/unstructured-hex-grid.md
@@ -1,3 +1,8 @@
+---
+seoTitle: unstructured-hex-grid Object for Evo Schemas | Seequent Developer
+description: Review the unstructured hex grid object schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import OverlineWithVersion from '@theme/OverlineWithVersion';
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/objects/unstructured-hex-grid-1.3.0.md';

--- a/docs/schemas/objects/unstructured-quad-grid.md
+++ b/docs/schemas/objects/unstructured-quad-grid.md
@@ -1,3 +1,8 @@
+---
+seoTitle: unstructured-quad-grid Object for Evo Schemas | Seequent Developer
+description: Review the unstructured quad grid object schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import OverlineWithVersion from '@theme/OverlineWithVersion';
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/objects/unstructured-quad-grid-1.3.0.md';

--- a/docs/schemas/objects/unstructured-tet-grid.md
+++ b/docs/schemas/objects/unstructured-tet-grid.md
@@ -1,3 +1,8 @@
+---
+seoTitle: unstructured-tet-grid Object for Evo Schemas | Seequent Developer
+description: Review the unstructured tet grid object schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import OverlineWithVersion from '@theme/OverlineWithVersion';
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/objects/unstructured-tet-grid-1.3.0.md';

--- a/docs/schemas/objects/variogram.md
+++ b/docs/schemas/objects/variogram.md
@@ -1,3 +1,8 @@
+---
+seoTitle: variogram Object for Evo Schemas | Seequent Developer
+description: Review the variogram object schema for Geoscience Objects, supporting consistent data structures and reliable Seequent Evo workflows.
+---
+
 import OverlineWithVersion from '@theme/OverlineWithVersion';
 import SchemaUri from '@theme/SchemaUri';
 import FlatProperties from '../generated/flatmd/objects/variogram-1.2.0.md';

--- a/docs/understanding-schemas/blob-storage.md
+++ b/docs/understanding-schemas/blob-storage.md
@@ -1,3 +1,8 @@
+---
+seoTitle: Blob Storage Understanding Schemas for Geoscience Objects | Seequent Developer
+description: Learn how blob storage works in Geoscience Objects schemas, with guidance for trusted Seequent Evo data workflows.
+---
+
 # Array storage
 
 ## File format

--- a/docs/understanding-schemas/cell-type-geometry.md
+++ b/docs/understanding-schemas/cell-type-geometry.md
@@ -1,3 +1,8 @@
+---
+seoTitle: Cell Type Geometry Understanding Schemas for Geoscience Objects | Seequent Developer
+description: Learn how cell type geometry works in Geoscience Objects schemas, with guidance for trusted Seequent Evo data workflows.
+---
+
 # Cell type geometry
 
 All binary blobs that store cell geometry such as tetrahedrons and hexahedrons should follow the convention taken in the VTK library for vertex ordering. This ensures that all consumers of the binary blob will know the vertex ordering and can transform it to fit their needs.

--- a/docs/understanding-schemas/understanding-attributes.md
+++ b/docs/understanding-schemas/understanding-attributes.md
@@ -1,3 +1,8 @@
+---
+seoTitle: Understanding Attributes Understanding Schemas for Geoscience Objects | Seequent Developer
+description: Learn how attributes works in Geoscience Objects schemas, with guidance for trusted Seequent Evo data workflows.
+---
+
 # Understanding attributes
 
 Most objects can have generic attributes associated with some of their components.

--- a/docs/understanding-schemas/understanding-parts.md
+++ b/docs/understanding-schemas/understanding-parts.md
@@ -1,3 +1,8 @@
+---
+seoTitle: Understanding Parts Understanding Schemas for Geoscience Objects | Seequent Developer
+description: Learn how parts works in Geoscience Objects schemas, with guidance for trusted Seequent Evo data workflows.
+---
+
 # Understanding parts
 
 We decompose complex geometry into parts.

--- a/docs/versioning-and-release-process/documentation-conventions.md
+++ b/docs/versioning-and-release-process/documentation-conventions.md
@@ -1,3 +1,11 @@
+---
+seoTitle: Documentation Conventions Versioning And Release Process for Geoscience Objects | Seequent Developer
+description: Review documentation conventions for Geoscience Objects, including schema governance practices that support reliable Seequent Evo data workflows.
+structuredData:
+  softwareSourceCode:
+    - name: Documentation Conventions | Seequent Developer Portal
+---
+
 import Alert from '@mui/material/Alert';
 
 # Documentation Conventions

--- a/docs/versioning-and-release-process/schema-development-lifecycle.md
+++ b/docs/versioning-and-release-process/schema-development-lifecycle.md
@@ -1,3 +1,8 @@
+---
+seoTitle: Schema Development Lifecycle Versioning And Release Process for Geoscience Objects | Seequent Developer
+description: Review schema development lifecycle for Geoscience Objects, including schema governance practices that support reliable Seequent Evo data workflows.
+---
+
 import Alert from '@mui/material/Alert';
 
 # Schema Development Lifecycle

--- a/docs/versioning-and-release-process/schema-versioning-policy.md
+++ b/docs/versioning-and-release-process/schema-versioning-policy.md
@@ -1,3 +1,8 @@
+---
+seoTitle: Schema Versioning Policy Versioning And Release Process for Geoscience Objects | Seequent Developer
+description: Review schema versioning policy for Geoscience Objects, including versioning practices that support reliable Seequent Evo data workflows.
+---
+
 import Alert from '@mui/material/Alert';
 
 # Schema Versioning Policy


### PR DESCRIPTION
## Summary

- Add SEO titles and descriptions to the Geoscience Objects documentation frontmatter.
- Keep the metadata with the authoritative `evo-schemas` content so it is carried into the Developer Portal during import.
- Add structured-data source metadata where applicable.

## Validation

- Checked all 167 modified Markdown files for frontmatter delimiters and required `seoTitle` and `description` fields.
- `git diff --check` passed.
- Python-based tests and pre-commit hooks were not run because Python is not installed in this environment.